### PR TITLE
added -trimpath to use module paths in build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,7 @@ builds:
       - arm64
     main: ./cmd/main
     ldflags: '-s -w -X github.com/tunnels-is/tunnels/version.Version={{.Version}} -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
+    flags: [ '-trimpath' ]
 
   - id: server
     goos:
@@ -37,6 +38,7 @@ builds:
       - arm
     main: ./server
     ldflags: '-s -w -X github.com/tunnels-is/tunnels/version.Version={{.Version}} -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
+    flags: [ '-trimpath' ]
 
   - id: min
     goos:
@@ -47,6 +49,7 @@ builds:
       - arm
     main: ./cmd/min
     ldflags: '-s -w -X github.com/tunnels-is/tunnels/version.Version={{.Version}} -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser'
+    flags: [ '-trimpath' ]
 
 dist: ./builds
 


### PR DESCRIPTION
this obfuscates absolute file paths from built binary. 
```
-trimpath
	remove all file system paths from the resulting executable.
	Instead of absolute file system paths, the recorded file names
	will begin either a module path@version (when using modules),
	or a plain import path (when using the standard library, or GOPATH).
```