### PR TITLE
Minor updates

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tunnels-is/tunnels/certs"
 	"github.com/tunnels-is/tunnels/types"
+	"gopkg.in/yaml.v3"
 )
 
 // writeConfigToDisk writes the current configuration to disk
@@ -20,9 +21,25 @@ func writeConfigToDisk() (err error) {
 	conf := CONFIG.Load()
 	s := STATE.Load()
 
-	cb, err := json.Marshal(conf)
-	if err != nil {
-		ERROR("Unable to marshal config into bytes: ", err)
+	var cb []byte
+	ext := strings.ToLower(filepath.Ext(s.ConfigFileName))
+
+	switch ext {
+	case ".yaml", ".yml":
+		cb, err = yaml.Marshal(conf)
+		if err != nil {
+			ERROR("Unable to marshal config into YAML bytes: ", err)
+			return err
+		}
+	case ".json", ".conf", "":
+		cb, err = json.MarshalIndent(conf, "", "    ")
+		if err != nil {
+			ERROR("Unable to marshal config into JSON bytes: ", err)
+			return err
+		}
+	default:
+		err = fmt.Errorf("unsupported config file format: %s (supported: .json, .yaml, .yml, .conf)", ext)
+		ERROR(err)
 		return err
 	}
 
@@ -56,9 +73,24 @@ func ReadConfigFileFromDisk() (err error) {
 	}
 
 	Conf := new(configV2)
-	err = json.Unmarshal(config, Conf)
-	if err != nil {
-		ERROR("Unable to turn config file into config object: ", err)
+	ext := strings.ToLower(filepath.Ext(state.ConfigFileName))
+
+	switch ext {
+	case ".yaml", ".yml":
+		err = yaml.Unmarshal(config, Conf)
+		if err != nil {
+			ERROR("Unable to unmarshal YAML config file: ", err)
+			return
+		}
+	case ".json", ".conf", "":
+		err = json.Unmarshal(config, Conf)
+		if err != nil {
+			ERROR("Unable to unmarshal JSON config file: ", err)
+			return
+		}
+	default:
+		err = fmt.Errorf("unsupported config file format: %s (supported: .json, .yaml, .yml, .conf)", ext)
+		ERROR(err)
 		return
 	}
 
@@ -164,9 +196,29 @@ func writeTunnelsToDisk(tag string) (outErr error) {
 				return true
 			}
 		}
-		tb, err := json.Marshal(value)
-		if err != nil {
-			ERROR("Unable to transform tunnel to json:", err)
+
+		var tb []byte
+		var err error
+		ext := strings.ToLower(filepath.Ext(tunnelFileSuffix))
+
+		switch ext {
+		case ".yaml", ".yml":
+			tb, err = yaml.Marshal(value)
+			if err != nil {
+				ERROR("Unable to transform tunnel to YAML:", err)
+				outErr = err
+				return false
+			}
+		case ".json", ".conf", "":
+			tb, err = json.MarshalIndent(value, "", "    ")
+			if err != nil {
+				ERROR("Unable to transform tunnel to JSON:", err)
+				outErr = err
+				return false
+			}
+		default:
+			err = fmt.Errorf("unsupported tunnel file format: %s (supported: .json, .yaml, .yml, .conf)", ext)
+			ERROR(err)
 			outErr = err
 			return false
 		}
@@ -185,7 +237,7 @@ func writeTunnelsToDisk(tag string) (outErr error) {
 
 		_, err = tf.Write(tb)
 		if err != nil {
-			ERROR("Unable to write tunnel json to file:", err)
+			ERROR("Unable to write tunnel to file:", err)
 			outErr = err
 			return false
 		}
@@ -213,7 +265,11 @@ func loadTunnelsFromDisk() (err error) {
 			return nil
 		}
 
-		if !strings.HasSuffix(path, tunnelFileSuffix) {
+		// Support both .conf (default), .json, .yaml, and .yml files
+		ext := strings.ToLower(filepath.Ext(path))
+		isSupportedFormat := ext == ".conf" || ext == ".json" || ext == ".yaml" || ext == ".yml"
+
+		if !isSupportedFormat {
 			return nil
 		}
 
@@ -224,11 +280,26 @@ func loadTunnelsFromDisk() (err error) {
 		}
 
 		tunnel := new(TunnelMETA)
-		merr := json.Unmarshal(tb, tunnel)
-		if merr != nil {
-			ERROR("Unable to marshal tunnel file:", err)
-			return err
+		var merr error
+
+		switch ext {
+		case ".yaml", ".yml":
+			merr = yaml.Unmarshal(tb, tunnel)
+			if merr != nil {
+				ERROR("Unable to unmarshal YAML tunnel file:", merr)
+				return merr
+			}
+		case ".json", ".conf", "":
+			merr = json.Unmarshal(tb, tunnel)
+			if merr != nil {
+				ERROR("Unable to unmarshal JSON tunnel file:", merr)
+				return merr
+			}
+		default:
+			ERROR("Unsupported tunnel file format:", ext)
+			return fmt.Errorf("unsupported tunnel file format: %s", ext)
 		}
+
 		TunnelMetaMap.Store(tunnel.Tag, tunnel)
 		DEBUG("Loaded tunnel:", tunnel.Tag)
 		if tunnel.Tag == DefaultTunnelName {

--- a/client/config.go
+++ b/client/config.go
@@ -303,6 +303,11 @@ func loadTunnelsFromDisk() (err error) {
 			return fmt.Errorf("unsupported tunnel file format: %s", ext)
 		}
 
+		if tunnel.Tag == "" {
+			ERROR("Skipping tunnel file with empty Tag:", path)
+			return nil
+		}
+
 		tunnel.ConfigFormat = ext
 		TunnelMetaMap.Store(tunnel.Tag, tunnel)
 		DEBUG("Loaded tunnel:", tunnel.Tag)

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -1,9 +1,15 @@
 package client
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tunnels-is/tunnels/certs"
+	"github.com/tunnels-is/tunnels/types"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -204,4 +210,555 @@ func TestApplyCertificateDefaultsToConfig(t *testing.T) {
 	}
 
 	t.Logf("Certificate defaults application test passed")
+}
+
+func TestWriteConfigToDisk_JSON(t *testing.T) {
+	// Save original state and config
+	originalState := STATE.Load()
+	originalConfig := CONFIG.Load()
+	defer func() {
+		STATE.Store(originalState)
+		CONFIG.Store(originalConfig)
+	}()
+
+	tmpDir := t.TempDir()
+	testConfig := DefaultConfig()
+	testConfig.APIIP = "192.168.1.100"
+	testConfig.APIPort = "8888"
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "write JSON config",
+			filename:    "config.json",
+			expectError: false,
+		},
+		{
+			name:        "write config with .conf extension (defaults to JSON)",
+			filename:    "config.conf",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Setup state with test config path
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+			CONFIG.Store(testConfig)
+
+			// Test writing
+			err := writeConfigToDisk()
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify file was created
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				t.Error("Config file was not created")
+				return
+			}
+
+			// Load and verify content
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Errorf("Failed to read saved config: %v", err)
+				return
+			}
+
+			var loaded configV2
+			if err := json.Unmarshal(data, &loaded); err != nil {
+				t.Errorf("Failed to unmarshal saved config: %v", err)
+				return
+			}
+
+			if loaded.APIIP != testConfig.APIIP {
+				t.Errorf("APIIP: got %s, expected %s", loaded.APIIP, testConfig.APIIP)
+			}
+			if loaded.APIPort != testConfig.APIPort {
+				t.Errorf("APIPort: got %s, expected %s", loaded.APIPort, testConfig.APIPort)
+			}
+
+			t.Log("JSON config saved successfully ✓")
+		})
+	}
+}
+
+func TestWriteConfigToDisk_YAML(t *testing.T) {
+	// Save original state and config
+	originalState := STATE.Load()
+	originalConfig := CONFIG.Load()
+	defer func() {
+		STATE.Store(originalState)
+		CONFIG.Store(originalConfig)
+	}()
+
+	tmpDir := t.TempDir()
+	testConfig := DefaultConfig()
+	testConfig.APIIP = "192.168.1.100"
+	testConfig.APIPort = "8888"
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "write YAML config with .yaml extension",
+			filename:    "config.yaml",
+			expectError: false,
+		},
+		{
+			name:        "write YAML config with .yml extension",
+			filename:    "config.yml",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Setup state with test config path
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+			CONFIG.Store(testConfig)
+
+			// Test writing
+			err := writeConfigToDisk()
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify file was created
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				t.Error("Config file was not created")
+				return
+			}
+
+			// Load and verify content
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Errorf("Failed to read saved config: %v", err)
+				return
+			}
+
+			var loaded configV2
+			if err := yaml.Unmarshal(data, &loaded); err != nil {
+				t.Errorf("Failed to unmarshal saved config: %v", err)
+				return
+			}
+
+			if loaded.APIIP != testConfig.APIIP {
+				t.Errorf("APIIP: got %s, expected %s", loaded.APIIP, testConfig.APIIP)
+			}
+			if loaded.APIPort != testConfig.APIPort {
+				t.Errorf("APIPort: got %s, expected %s", loaded.APIPort, testConfig.APIPort)
+			}
+
+			t.Logf("YAML config (%s) saved successfully ✓", tc.filename)
+		})
+	}
+}
+
+func TestReadConfigFileFromDisk_JSON(t *testing.T) {
+	// Save original state and config
+	originalState := STATE.Load()
+	originalConfig := CONFIG.Load()
+	defer func() {
+		STATE.Store(originalState)
+		CONFIG.Store(originalConfig)
+	}()
+
+	tmpDir := t.TempDir()
+	testConfig := DefaultConfig()
+	testConfig.APIIP = "10.0.0.1"
+	testConfig.APIPort = "9999"
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "load JSON config",
+			filename:    "config.json",
+			expectError: false,
+		},
+		{
+			name:        "load .conf config (JSON format)",
+			filename:    "config.conf",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Write test config to file
+			data, err := json.MarshalIndent(testConfig, "", "    ")
+			if err != nil {
+				t.Fatalf("Failed to marshal test config: %v", err)
+			}
+
+			if err := os.WriteFile(configPath, data, 0o644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			// Setup state with test config path
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+
+			// Test loading
+			err = ReadConfigFileFromDisk()
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify loaded config
+			loaded := CONFIG.Load()
+			if loaded.APIIP != testConfig.APIIP {
+				t.Errorf("APIIP: got %s, expected %s", loaded.APIIP, testConfig.APIIP)
+			}
+			if loaded.APIPort != testConfig.APIPort {
+				t.Errorf("APIPort: got %s, expected %s", loaded.APIPort, testConfig.APIPort)
+			}
+
+			t.Log("JSON config loaded successfully ✓")
+		})
+	}
+}
+
+func TestReadConfigFileFromDisk_YAML(t *testing.T) {
+	// Save original state and config
+	originalState := STATE.Load()
+	originalConfig := CONFIG.Load()
+	defer func() {
+		STATE.Store(originalState)
+		CONFIG.Store(originalConfig)
+	}()
+
+	tmpDir := t.TempDir()
+	testConfig := DefaultConfig()
+	testConfig.APIIP = "10.0.0.1"
+	testConfig.APIPort = "9999"
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "load YAML config with .yaml extension",
+			filename:    "config.yaml",
+			expectError: false,
+		},
+		{
+			name:        "load YAML config with .yml extension",
+			filename:    "config.yml",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Write test config to file
+			data, err := yaml.Marshal(testConfig)
+			if err != nil {
+				t.Fatalf("Failed to marshal test config: %v", err)
+			}
+
+			if err := os.WriteFile(configPath, data, 0o644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			// Setup state with test config path
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+
+			// Test loading
+			err = ReadConfigFileFromDisk()
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify loaded config
+			loaded := CONFIG.Load()
+			if loaded.APIIP != testConfig.APIIP {
+				t.Errorf("APIIP: got %s, expected %s", loaded.APIIP, testConfig.APIIP)
+			}
+			if loaded.APIPort != testConfig.APIPort {
+				t.Errorf("APIPort: got %s, expected %s", loaded.APIPort, testConfig.APIPort)
+			}
+
+			t.Logf("YAML config (%s) loaded successfully ✓", tc.filename)
+		})
+	}
+}
+
+func TestConfigFileErrors(t *testing.T) {
+	// Save original state
+	originalState := STATE.Load()
+	defer STATE.Store(originalState)
+
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		setupFunc   func() string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "unsupported file format",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "config.xml")
+				_ = os.WriteFile(path, []byte("<config></config>"), 0o644)
+				return path
+			},
+			expectError: true,
+			errorMsg:    "unsupported config file format",
+		},
+		{
+			name: "file does not exist",
+			setupFunc: func() string {
+				return filepath.Join(tmpDir, "nonexistent.json")
+			},
+			expectError: true,
+			errorMsg:    "no such file or directory",
+		},
+		{
+			name: "invalid JSON content",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "invalid.json")
+				_ = os.WriteFile(path, []byte("{invalid json}"), 0o644)
+				return path
+			},
+			expectError: true,
+			errorMsg:    "invalid character",
+		},
+		{
+			name: "invalid YAML content",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "invalid.yaml")
+				_ = os.WriteFile(path, []byte("invalid:\n  yaml:\n    - [unclosed"), 0o644)
+				return path
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := tc.setupFunc()
+
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+
+			err := ReadConfigFileFromDisk()
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else {
+					t.Logf("Got expected error: %v ✓", err)
+					if tc.errorMsg != "" && !strings.Contains(err.Error(), tc.errorMsg) {
+						t.Logf("Warning: expected error message to contain '%s', got '%s'", tc.errorMsg, err.Error())
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadAndSaveTunnels_JSON(t *testing.T) {
+	// Save original state
+	originalState := STATE.Load()
+	defer STATE.Store(originalState)
+
+	tmpDir := t.TempDir()
+	tunnelsPath := filepath.Join(tmpDir, "tunnels") + string(filepath.Separator)
+	err := os.MkdirAll(tunnelsPath, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create tunnels directory: %v", err)
+	}
+
+	// Setup state
+	testState := &stateV2{
+		TunnelsPath: tunnelsPath,
+		TunnelType:  string(types.DefaultTun),
+	}
+	STATE.Store(testState)
+
+	// Create test tunnel
+	testTunnel := &TunnelMETA{
+		Tag:          "test-tunnel",
+		ServerID:     "server1",
+		IPv4Address:  "10.0.0.1",
+		DNSBlocking:  true,
+		AutoConnect:  false,
+		AutoReconnect: false,
+	}
+	TunnelMetaMap.Store(testTunnel.Tag, testTunnel)
+
+	// Test writing
+	err = writeTunnelsToDisk(testTunnel.Tag)
+	if err != nil {
+		t.Fatalf("Failed to write tunnel: %v", err)
+	}
+
+	// Clear map and test loading
+	TunnelMetaMap.Delete(testTunnel.Tag)
+
+	err = loadTunnelsFromDisk()
+	if err != nil {
+		t.Fatalf("Failed to load tunnels: %v", err)
+	}
+
+	// Verify loaded tunnel
+	loaded, ok := TunnelMetaMap.Load(testTunnel.Tag)
+	if !ok {
+		t.Error("Tunnel was not loaded")
+		return
+	}
+
+	if loaded.ServerID != testTunnel.ServerID {
+		t.Errorf("ServerID: got %s, expected %s", loaded.ServerID, testTunnel.ServerID)
+	}
+	if loaded.IPv4Address != testTunnel.IPv4Address {
+		t.Errorf("IPv4Address: got %s, expected %s", loaded.IPv4Address, testTunnel.IPv4Address)
+	}
+	if loaded.DNSBlocking != testTunnel.DNSBlocking {
+		t.Errorf("DNSBlocking: got %v, expected %v", loaded.DNSBlocking, testTunnel.DNSBlocking)
+	}
+
+	t.Log("Tunnel JSON save/load cycle completed successfully ✓")
+}
+
+func TestConfigRoundTrip(t *testing.T) {
+	// Save original state and config
+	originalState := STATE.Load()
+	originalConfig := CONFIG.Load()
+	defer func() {
+		STATE.Store(originalState)
+		CONFIG.Store(originalConfig)
+	}()
+
+	tmpDir := t.TempDir()
+	testConfig := DefaultConfig()
+	testConfig.APIIP = "172.16.0.1"
+	testConfig.APIPort = "12345"
+	testConfig.DNSServerIP = "8.8.8.8"
+	testConfig.DNSServerPort = "5353"
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "JSON round trip",
+			filename: "roundtrip.json",
+		},
+		{
+			name:     "YAML round trip",
+			filename: "roundtrip.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Setup and save
+			testState := &stateV2{
+				ConfigFileName: configPath,
+			}
+			STATE.Store(testState)
+			CONFIG.Store(testConfig)
+
+			if err := writeConfigToDisk(); err != nil {
+				t.Fatalf("Failed to write config: %v", err)
+			}
+
+			// Load back
+			if err := ReadConfigFileFromDisk(); err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+
+			// Verify all fields match
+			loaded := CONFIG.Load()
+			if loaded.APIIP != testConfig.APIIP {
+				t.Errorf("APIIP: got %s, expected %s", loaded.APIIP, testConfig.APIIP)
+			}
+			if loaded.APIPort != testConfig.APIPort {
+				t.Errorf("APIPort: got %s, expected %s", loaded.APIPort, testConfig.APIPort)
+			}
+			if loaded.DNSServerIP != testConfig.DNSServerIP {
+				t.Errorf("DNSServerIP: got %s, expected %s", loaded.DNSServerIP, testConfig.DNSServerIP)
+			}
+			if loaded.DNSServerPort != testConfig.DNSServerPort {
+				t.Errorf("DNSServerPort: got %s, expected %s", loaded.DNSServerPort, testConfig.DNSServerPort)
+			}
+
+			t.Logf("Round trip test passed for %s ✓", tc.filename)
+		})
+	}
 }

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -650,11 +650,10 @@ func TestLoadAndSaveTunnels_JSON(t *testing.T) {
 
 	// Create test tunnel
 	testTunnel := &TunnelMETA{
-		Tag:          "test-tunnel",
-		ServerID:     "server1",
-		IPv4Address:  "10.0.0.1",
-		DNSBlocking:  true,
-		AutoConnect:  false,
+		Tag:           "test-tunnel",
+		IPv4Address:   "10.0.0.1",
+		DNSBlocking:   true,
+		AutoConnect:   false,
 		AutoReconnect: false,
 	}
 	TunnelMetaMap.Store(testTunnel.Tag, testTunnel)
@@ -680,9 +679,6 @@ func TestLoadAndSaveTunnels_JSON(t *testing.T) {
 		return
 	}
 
-	if loaded.ServerID != testTunnel.ServerID {
-		t.Errorf("ServerID: got %s, expected %s", loaded.ServerID, testTunnel.ServerID)
-	}
 	if loaded.IPv4Address != testTunnel.IPv4Address {
 		t.Errorf("IPv4Address: got %s, expected %s", loaded.IPv4Address, testTunnel.IPv4Address)
 	}

--- a/client/http_layer.go
+++ b/client/http_layer.go
@@ -452,7 +452,11 @@ func HTTP_SetTunnel(w http.ResponseWriter, r *http.Request) {
 	if newForm.OldTag != newForm.Meta.Tag {
 		TunnelMetaMap.Delete(newForm.OldTag)
 		state := STATE.Load()
-		err = os.Remove(state.TunnelsPath + newForm.OldTag + tunnelFileSuffix)
+		ext := newForm.Meta.ConfigFormat
+		if ext == "" {
+			ext = tunnelFileSuffix
+		}
+		err = os.Remove(state.TunnelsPath + newForm.OldTag + ext)
 		if err != nil {
 			JSON(w, r, 400, err.Error())
 			return
@@ -519,7 +523,13 @@ func HTTP_DeleteTunnels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	state := STATE.Load()
-	_ = os.Remove(state.TunnelsPath + form.Tag + tunnelFileSuffix)
+	ext := tunnelFileSuffix
+	if storedTun, ok := TunnelMetaMap.Load(form.Tag); ok {
+		if storedTun.ConfigFormat != "" {
+			ext = storedTun.ConfigFormat
+		}
+	}
+	_ = os.Remove(state.TunnelsPath + form.Tag + ext)
 
 	tunnelMetaMapRange(func(tun *TunnelMETA) bool {
 		if tun.Tag == form.Tag {

--- a/client/main.go
+++ b/client/main.go
@@ -73,7 +73,7 @@ func InitService() error {
 			conf.OpenUI = false
 			wasChanged = true
 		}
-		if conf.ConsoleLogOnly {
+		if !conf.ConsoleLogOnly {
 			conf.ConsoleLogOnly = true
 			wasChanged = true
 		}

--- a/client/main.go
+++ b/client/main.go
@@ -73,6 +73,7 @@ func InitService() error {
 			conf.OpenUI = false
 			wasChanged = true
 		}
+		// CLI mode always forces console log only
 		if !conf.ConsoleLogOnly {
 			conf.ConsoleLogOnly = true
 			wasChanged = true

--- a/client/structs_globals.go
+++ b/client/structs_globals.go
@@ -302,9 +302,9 @@ type ActiveConnectionMeta struct {
 }
 
 type TunnelMETA struct {
-	WindowsGUID string
+	WindowsGUID  string
+	ConfigFormat string
 
-	// controlled by user only
 	DNSBlocking     bool
 	LocalhostNat    bool
 	AutoReconnect   bool

--- a/client/structs_globals.go
+++ b/client/structs_globals.go
@@ -546,8 +546,8 @@ type CLIConfig struct {
 	DeviceID         string
 	ServerID         string
 	SendStats        bool
-	PinVersion       bool // deprecated
-	SkipUpdatePrompt bool // deprecated
+	PinVersion       bool
+	SkipUpdatePrompt bool
 }
 
 type configV2 struct {
@@ -564,8 +564,6 @@ type configV2 struct {
 	UpdateWhileConnected bool
 	UpdateCheckInterval  int
 	DisableUpdates       bool
-	SkipUpdatePrompt     bool
-	PinVersion           bool
 
 	// API Setting
 	APIIP          string

--- a/client/structs_globals.go
+++ b/client/structs_globals.go
@@ -546,8 +546,8 @@ type CLIConfig struct {
 	DeviceID         string
 	ServerID         string
 	SendStats        bool
-	PinVersion       bool
-	SkipUpdatePrompt bool
+	PinVersion       bool // deprecated
+	SkipUpdatePrompt bool // deprecated
 }
 
 type configV2 struct {
@@ -564,6 +564,8 @@ type configV2 struct {
 	UpdateWhileConnected bool
 	UpdateCheckInterval  int
 	DisableUpdates       bool
+	SkipUpdatePrompt     bool
+	PinVersion           bool
 
 	// API Setting
 	APIIP          string

--- a/client/tunnel.go
+++ b/client/tunnel.go
@@ -106,6 +106,7 @@ func createDefaultTunnelMeta(t types.TunnelType) (M *TunnelMETA) {
 	M.RequestVPNPorts = true
 	M.IPv4Address = "172.22.22.1"
 	M.NetMask = "255.255.255.255"
+	M.ConfigFormat = tunnelFileSuffix
 
 	M.Tag = DefaultTunnelName
 	M.IFName = DefaultTunnelName

--- a/client/tunnel.go
+++ b/client/tunnel.go
@@ -119,7 +119,7 @@ func createDefaultTunnelMeta(t types.TunnelType) (M *TunnelMETA) {
 		M.LocalhostNat = true
 		M.AutoConnect = true
 		M.AutoReconnect = true
-		M.MTU = 1320 // MTU is set low here due to many 5g networks. The LAN tunnels is mostly used to IoT.
+		M.MTU = 1320 // MTU is set low here due to mobile networks
 	}
 
 	return

--- a/client/update.go
+++ b/client/update.go
@@ -39,7 +39,7 @@ func updatePrint(s ...any) {
 func isPinned() (pinned bool) {
 	conf := CONFIG.Load()
 	if conf.CLIConfig != nil {
-		if conf.CLIConfig.PinVersion {
+		if conf.CLIConfig.PinVersion || conf.PinVersion {
 			return true
 		}
 	}
@@ -49,7 +49,7 @@ func isPinned() (pinned bool) {
 func skipUpdatePrompt() (pinned bool) {
 	conf := CONFIG.Load()
 	if conf.CLIConfig != nil {
-		if conf.CLIConfig.SkipUpdatePrompt {
+		if conf.CLIConfig.SkipUpdatePrompt || conf.SkipUpdatePrompt {
 			return true
 		}
 	}

--- a/client/update.go
+++ b/client/update.go
@@ -39,7 +39,7 @@ func updatePrint(s ...any) {
 func isPinned() (pinned bool) {
 	conf := CONFIG.Load()
 	if conf.CLIConfig != nil {
-		if conf.CLIConfig.PinVersion || conf.PinVersion {
+		if conf.CLIConfig.PinVersion {
 			return true
 		}
 	}
@@ -49,7 +49,7 @@ func isPinned() (pinned bool) {
 func skipUpdatePrompt() (pinned bool) {
 	conf := CONFIG.Load()
 	if conf.CLIConfig != nil {
-		if conf.CLIConfig.SkipUpdatePrompt || conf.SkipUpdatePrompt {
+		if conf.CLIConfig.SkipUpdatePrompt {
 			return true
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,5 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.70 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tunnels-is/tunnels
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/NdoleStudio/lemonsqueezy-go v1.2.4

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/net v0.47.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.37.0
+	gopkg.in/yaml.v3 v3.0.1
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.70
 )
 

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -1,0 +1,81 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - durationcheck
+    - forcetypeassert
+    - gocritic
+    - gomodguard
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+    - usetesting
+    - whitespace
+    - testifylint
+  settings:
+    misspell:
+      locale: US
+    staticcheck:
+      checks:
+        - all
+        - -SA1008
+        - -SA1019
+        - -SA4000
+        - -SA9004
+        - -ST1000
+        - -ST1005
+        - -ST1016
+        - -U1000
+        - -SA5011
+    testifylint:
+      disable:
+        - go-require
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - forcetypeassert
+        path: _test\.go
+      - path: (.+)\.go$
+        text: "empty-block:"
+      - path: (.+)\.go$
+        text: "unused-parameter:"
+      - path: (.+)\.go$
+        text: "dot-imports:"
+      - path: (.+)\.go$
+        text: should have a package comment
+      - path: (.+)\.go$
+        text: error strings should not be capitalized or end with punctuation or a newline
+      - path: (.+)\.go$
+        text: could be replaced by b.Context()
+      - path: (.+)\.go$
+        text: could be replaced by t.Context()
+      - path: (.+)\.go$
+        text: could be replaced by tb.Context()
+      - path: (.+)\.go$
+        text: ineffectual assignment to ctx
+      - path: (.+)\.go$
+        text: this value of ctx is never used
+      - path: internal/logger/target/types/*
+        text: avoid meaningless package names
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 100
+  max-same-issues: 100
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/server/bboltwrapper.go
+++ b/server/bboltwrapper.go
@@ -355,7 +355,7 @@ func BBolt_FindServersWithoutGroups(limit, offset int64) ([]*types.Server, error
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			S := new(types.Server)
 			if err := bboltUnmarshal(v, S); err == nil {
-				if S.Groups == nil || len(S.Groups) == 0 {
+				if len(S.Groups) == 0 {
 					if skipped < offset {
 						skipped++
 						continue
@@ -701,7 +701,7 @@ func BBolt_AddToGroup(groupID, typeID, objType string) error {
 		switch objType {
 		case "device":
 			D := new(types.Device)
-			err = bboltUnmarshal(v, D)
+			_ = bboltUnmarshal(v, D)
 			groups := objectIDSliceToString(D.Groups)
 			if !contains(groups, groupID) {
 				groups = append(groups, groupID)
@@ -714,7 +714,7 @@ func BBolt_AddToGroup(groupID, typeID, objType string) error {
 			return b.Put([]byte(typeID), v)
 		case "user":
 			U := new(User)
-			err = bboltUnmarshal(v, U)
+			_ = bboltUnmarshal(v, U)
 			groups := objectIDSliceToString(U.Groups)
 			if !contains(groups, groupID) {
 				groups = append(groups, groupID)
@@ -723,7 +723,7 @@ func BBolt_AddToGroup(groupID, typeID, objType string) error {
 			v, err = bboltMarshal(U)
 		case "server":
 			S := new(types.Server)
-			err = bboltUnmarshal(v, S)
+			_ = bboltUnmarshal(v, S)
 			groups := objectIDSliceToString(S.Groups)
 			if !contains(groups, groupID) {
 				groups = append(groups, groupID)
@@ -761,21 +761,21 @@ func BBolt_RemoveFromGroup(groupID, typeID, objType string) error {
 		switch objType {
 		case "user":
 			U := new(User)
-			err = bboltUnmarshal(v, U)
+			_ = bboltUnmarshal(v, U)
 			groups := objectIDSliceToString(U.Groups)
 			groups = removeString(groups, groupID)
 			U.Groups = stringSliceToObjectID(groups)
 			v, err = bboltMarshal(U)
 		case "server":
 			S := new(types.Server)
-			err = bboltUnmarshal(v, S)
+			_ = bboltUnmarshal(v, S)
 			groups := objectIDSliceToString(S.Groups)
 			groups = removeString(groups, groupID)
 			S.Groups = stringSliceToObjectID(groups)
 			v, err = bboltMarshal(S)
 		case "device":
 			D := new(types.Device)
-			err = bboltUnmarshal(v, D)
+			_ = bboltUnmarshal(v, D)
 			groups := objectIDSliceToString(D.Groups)
 			groups = removeString(groups, groupID)
 			D.Groups = stringSliceToObjectID(groups)
@@ -821,7 +821,7 @@ func removeString(slice []string, s string) []string {
 }
 
 // Helper: convert primitive.ObjectID to string and vice versa
-func objectIDToString(id interface{}) string {
+func objectIDToString(id any) string {
 	switch v := id.(type) {
 	case string:
 		return v
@@ -835,7 +835,7 @@ func objectIDToString(id interface{}) string {
 }
 
 // Helper: convert []primitive.ObjectID <-> []string
-func objectIDSliceToString(slice interface{}) []string {
+func objectIDSliceToString(slice any) []string {
 	var out []string
 	switch v := slice.(type) {
 	case []string:

--- a/server/dbwrapper.go
+++ b/server/dbwrapper.go
@@ -48,20 +48,20 @@ func ConnectToDB(connectionString string) (err error) {
 
 	DB, err = mongo.Connect(context.Background(), opt.ApplyURI(connectionString))
 	if err != nil {
-		ERR(3, err)
-		ADMIN(3, "Database error, unable to connect local")
+		ERR( err)
+		ADMIN( "Database error, unable to connect local")
 		return
 	}
 
 	err = DB.Ping(context.Background(), nil)
 	if err != nil {
 		_ = DB.Disconnect(context.TODO())
-		ERR(3, err)
-		ADMIN(3, "Database error, unable to ping local")
+		ERR( err)
+		ADMIN( "Database error, unable to ping local")
 		return
 	}
 
-	INFO(3, "DATABASE CONNECTED")
+	INFO( "DATABASE CONNECTED")
 	return
 }
 
@@ -82,7 +82,7 @@ func DB_DeleteDeviceByID(id primitive.ObjectID) (err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to delete device by id: ", id, err)
+		ADMIN( "Unable to delete device by id: ", id, err)
 		return err
 	}
 
@@ -118,11 +118,11 @@ func DB_UpdateDevice(D *types.Device) (err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN(3, "Unable to update device", D.ID.Hex(), err)
+		ADMIN( "Unable to update device", D.ID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to update device(no match count)", D.ID.Hex(), err)
+		ADMIN( "Unable to update device(no match count)", D.ID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
@@ -149,7 +149,7 @@ func DB_GetDevices(limit, offset int64) (DL []*types.Device, err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to find device: ", err)
+		ADMIN( "Unable to find device: ", err)
 		return nil, err
 	}
 
@@ -158,7 +158,7 @@ func DB_GetDevices(limit, offset int64) (DL []*types.Device, err error) {
 		D := new(types.Device)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN(3, "Unable to decode user to struct: ", err)
+			ADMIN( "Unable to decode user to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
@@ -187,7 +187,7 @@ func DB_getUsers(limit, offset int64) (UL []*User, err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to find users: ", err)
+		ADMIN( "Unable to find users: ", err)
 		return nil, err
 	}
 
@@ -196,7 +196,7 @@ func DB_getUsers(limit, offset int64) (UL []*User, err error) {
 		D := new(User)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN(3, "Unable to decode user to struct: ", err)
+			ADMIN( "Unable to decode user to struct: ", err)
 			continue
 		}
 		UL = append(UL, D)
@@ -225,7 +225,7 @@ func DB_findUserByAPIKey(Key string) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -251,7 +251,7 @@ func DB_findUserByID(UID primitive.ObjectID) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -270,7 +270,7 @@ func DB_CreateUser(U *User) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -293,7 +293,7 @@ func DB_findUserByEmail(Email string) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -321,7 +321,7 @@ func DB_updateUserDeviceTokens(TU *UPDATE_USER_TOKENS) (err error) {
 			},
 		)
 	if err != nil {
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -353,12 +353,12 @@ func DB_updateUserSubTime(u *User) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Could not update user sub time: ", err)
+		ADMIN( "Could not update user sub time: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Could not update user sub time: ", err)
+		ADMIN( "Could not update user sub time: ", err)
 		return errors.New("unable to modify document")
 	}
 
@@ -392,12 +392,12 @@ func DB_updateUser(UF *USER_UPDATE_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Could not update user: ", err)
+		ADMIN( "Could not update user: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Could not update user: ", err)
+		ADMIN( "Could not update user: ", err)
 		return errors.New("unable to modify document")
 	}
 
@@ -442,12 +442,12 @@ func DB_updateUserAdmin(UF *USER_ADMIN_UPDATE_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Could not admin update user: ", err)
+		ADMIN( "Could not admin update user: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Could not admin update user: user not found")
+		ADMIN( "Could not admin update user: user not found")
 		return errors.New("unable to modify document")
 	}
 
@@ -480,12 +480,12 @@ func DB_toggleUserSubscriptionStatus(UF *USER_UPDATE_SUB_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Could not update user sub status: ", err)
+		ADMIN( "Could not update user sub status: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Could not update user sub status: ", err)
+		ADMIN( "Could not update user sub status: ", err)
 		return errors.New("unable to modify document")
 	}
 
@@ -515,7 +515,7 @@ func DB_userUpdateTwoFactorCodes(TFP *TWO_FACTOR_DB_PACKAGE) (err error) {
 			},
 		)
 	if err != nil {
-		ADMIN(3, err)
+		ADMIN( err)
 	}
 
 	return
@@ -544,12 +544,12 @@ func DB_userResetPassword(user *User) error {
 			},
 		)
 	if err != nil {
-		ADMIN(3, "Unable to modify user password: ", user.ID)
+		ADMIN( "Unable to modify user password: ", user.ID)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to modify user password: ", user.ID)
+		ADMIN( "Unable to modify user password: ", user.ID)
 		return errors.New("user password could not be modified")
 	}
 
@@ -582,7 +582,7 @@ func DB_FindServersWithoutGroups(limit, offset int64) (DL []*types.Server, err e
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to find online devices: ", err)
+		ADMIN( "Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -591,7 +591,7 @@ func DB_FindServersWithoutGroups(limit, offset int64) (DL []*types.Server, err e
 		D := new(types.Server)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN(3, "Unable to decode device to struct: ", err)
+			ADMIN( "Unable to decode device to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
@@ -624,7 +624,7 @@ func DB_FindServersByGroups(groups []primitive.ObjectID, limit, offset int64) (D
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to find online devices: ", err)
+		ADMIN( "Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -633,7 +633,7 @@ func DB_FindServersByGroups(groups []primitive.ObjectID, limit, offset int64) (D
 		D := new(types.Server)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN(3, "Unable to decode device to struct: ", err)
+			ADMIN( "Unable to decode device to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
@@ -680,7 +680,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to find online devices: ", err)
+		ADMIN( "Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -691,7 +691,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(types.Server)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN(3, "Unable to decode device to struct: ", err)
+				ADMIN( "Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
@@ -699,7 +699,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(User)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN(3, "Unable to decode device to struct: ", err)
+				ADMIN( "Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
@@ -707,7 +707,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(types.Device)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN(3, "Unable to decode device to struct: ", err)
+				ADMIN( "Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
@@ -747,11 +747,11 @@ func DB_UpdateGroup(G *Group) (err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN(3, "Unable to update group", G.ID.Hex(), err)
+		ADMIN( "Unable to update group", G.ID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to update group(no match count)", G.ID.Hex(), err)
+		ADMIN( "Unable to update group(no match count)", G.ID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
@@ -789,7 +789,7 @@ func DB_UpdateServer(S *types.Server) (RS *types.Server, err error) {
 			options.FindOneAndUpdate(),
 		).Decode(&RS)
 	if err != nil {
-		ADMIN(3, "Unable to update server: ", S.ID.Hex())
+		ADMIN( "Unable to update server: ", S.ID.Hex())
 		return nil, err
 	}
 
@@ -810,7 +810,7 @@ func DB_CreateDevice(D *types.Device) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN(3, "Unable to create device: ", err)
+		ADMIN( "Unable to create device: ", err)
 		return err
 	}
 
@@ -831,7 +831,7 @@ func DB_CreateGroup(G *Group) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN(3, "Unable to create group: ", err)
+		ADMIN( "Unable to create group: ", err)
 		return err
 	}
 
@@ -852,7 +852,7 @@ func DB_CreateServer(S *types.Server) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN(3, "Unable to create server: ", err)
+		ADMIN( "Unable to create server: ", err)
 		return err
 	}
 
@@ -878,7 +878,7 @@ func DB_FindServerByID(ID primitive.ObjectID) (S *types.Server, err error) {
 			options.FindOne(),
 		).Decode(S)
 	if err != nil {
-		ADMIN(3, "Could not find server by id: ", ID, " / ", err)
+		ADMIN( "Could not find server by id: ", ID, " / ", err)
 		return nil, err
 	}
 
@@ -911,13 +911,13 @@ func DB_WipeUserConfirmCode(UF *USER_ENABLE_QUERY) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Could not enable user: ", err)
+		ADMIN( "Could not enable user: ", err)
 		return err
 	}
 
-	// INFO(3, "COUNTS:", res.MatchedCount, res.ModifiedCount)
+	// INFO( "COUNTS:", res.MatchedCount, res.ModifiedCount)
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Could not enable user, user no found: ", err)
+		ADMIN( "Could not enable user, user no found: ", err)
 		return errors.New("unable to modify document")
 	}
 
@@ -953,12 +953,12 @@ func DB_UserActivateKey(SubExpiration time.Time, Key *LicenseKey, userID primiti
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN(3, "Unable to update user post payment: ", userID, " / ", err)
+		ADMIN( "Unable to update user post payment: ", userID, " / ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to update user post payment: ", userID)
+		ADMIN( "Unable to update user post payment: ", userID)
 		return errors.New("unable to modify document")
 	}
 
@@ -1010,11 +1010,11 @@ func DB_AddToGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, objTyp
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN(3, "Unable to update object", objType, typeID.Hex(), err)
+		ADMIN( "Unable to update object", objType, typeID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to update (no match count)", objType, typeID.Hex(), err)
+		ADMIN( "Unable to update (no match count)", objType, typeID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
@@ -1066,11 +1066,11 @@ func DB_RemoveFromGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, o
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN(3, "Unable to update object", objType, typeID.Hex(), err)
+		ADMIN( "Unable to update object", objType, typeID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN(3, "Unable to update (no match count)", objType, typeID.Hex(), err)
+		ADMIN( "Unable to update (no match count)", objType, typeID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
@@ -1098,7 +1098,7 @@ func DB_FindDeviceByID(id primitive.ObjectID) (dev *types.Device, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN(3, "Unable to find device by id :", id, err)
+		ADMIN( "Unable to find device by id :", id, err)
 		return nil, err
 	}
 
@@ -1123,7 +1123,7 @@ func DB_findGroupByID(id primitive.ObjectID) (G *Group, err error) {
 			opt,
 		).Decode(&G)
 	if err != nil {
-		ADMIN(3, "Unable to find group by id: ", id, err)
+		ADMIN( "Unable to find group by id: ", id, err)
 		return nil, err
 	}
 
@@ -1147,7 +1147,7 @@ func DB_DeleteGroupByID(id primitive.ObjectID) (err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN(3, "Unable to delete group by id: ", id, err)
+		ADMIN( "Unable to delete group by id: ", id, err)
 		return err
 	}
 
@@ -1170,7 +1170,7 @@ func DB_findGroups() (gl []*Group, err error) {
 		opt,
 	)
 	if err != nil {
-		ADMIN(3, "Unable to find groups: ", err)
+		ADMIN( "Unable to find groups: ", err)
 		return nil, err
 	}
 
@@ -1179,7 +1179,7 @@ func DB_findGroups() (gl []*Group, err error) {
 		D := new(Group)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN(3, "Unable to decode group to struct: ", err)
+			ADMIN( "Unable to decode group to struct: ", err)
 			continue
 		}
 		gl = append(gl, D)

--- a/server/dbwrapper.go
+++ b/server/dbwrapper.go
@@ -48,21 +48,21 @@ func ConnectToDB(connectionString string) (err error) {
 
 	DB, err = mongo.Connect(context.Background(), opt.ApplyURI(connectionString))
 	if err != nil {
-		ERR( err)
-		ADMIN( "Database error, unable to connect local")
-		return
+		ERR(err)
+		ADMIN("Database error, unable to connect local")
+		return err
 	}
 
 	err = DB.Ping(context.Background(), nil)
 	if err != nil {
 		_ = DB.Disconnect(context.TODO())
-		ERR( err)
-		ADMIN( "Database error, unable to ping local")
-		return
+		ERR(err)
+		ADMIN("Database error, unable to ping local")
+		return err
 	}
 
-	INFO( "DATABASE CONNECTED")
-	return
+	INFO("DATABASE CONNECTED")
+	return err
 }
 
 func DB_DeleteDeviceByID(id primitive.ObjectID) (err error) {
@@ -82,11 +82,11 @@ func DB_DeleteDeviceByID(id primitive.ObjectID) (err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to delete device by id: ", id, err)
+		ADMIN("Unable to delete device by id: ", id, err)
 		return err
 	}
 
-	return
+	return err
 }
 
 func DB_UpdateDevice(D *types.Device) (err error) {
@@ -118,15 +118,15 @@ func DB_UpdateDevice(D *types.Device) (err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN( "Unable to update device", D.ID.Hex(), err)
+		ADMIN("Unable to update device", D.ID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to update device(no match count)", D.ID.Hex(), err)
+		ADMIN("Unable to update device(no match count)", D.ID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_GetDevices(limit, offset int64) (DL []*types.Device, err error) {
@@ -149,7 +149,7 @@ func DB_GetDevices(limit, offset int64) (DL []*types.Device, err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to find device: ", err)
+		ADMIN("Unable to find device: ", err)
 		return nil, err
 	}
 
@@ -158,13 +158,13 @@ func DB_GetDevices(limit, offset int64) (DL []*types.Device, err error) {
 		D := new(types.Device)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN( "Unable to decode user to struct: ", err)
+			ADMIN("Unable to decode user to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
 	}
 
-	return
+	return DL, err
 }
 
 func DB_getUsers(limit, offset int64) (UL []*User, err error) {
@@ -187,7 +187,7 @@ func DB_getUsers(limit, offset int64) (UL []*User, err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to find users: ", err)
+		ADMIN("Unable to find users: ", err)
 		return nil, err
 	}
 
@@ -196,13 +196,13 @@ func DB_getUsers(limit, offset int64) (UL []*User, err error) {
 		D := new(User)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN( "Unable to decode user to struct: ", err)
+			ADMIN("Unable to decode user to struct: ", err)
 			continue
 		}
 		UL = append(UL, D)
 	}
 
-	return
+	return UL, err
 }
 
 func DB_findUserByAPIKey(Key string) (USER *User, err error) {
@@ -225,10 +225,10 @@ func DB_findUserByAPIKey(Key string) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return USER, err
 }
 
 func DB_findUserByID(UID primitive.ObjectID) (USER *User, err error) {
@@ -251,10 +251,10 @@ func DB_findUserByID(UID primitive.ObjectID) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return USER, err
 }
 
 func DB_CreateUser(U *User) (err error) {
@@ -270,10 +270,10 @@ func DB_CreateUser(U *User) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return err
 }
 
 func DB_findUserByEmail(Email string) (USER *User, err error) {
@@ -293,10 +293,10 @@ func DB_findUserByEmail(Email string) (USER *User, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return USER, err
 }
 
 func DB_updateUserDeviceTokens(TU *UPDATE_USER_TOKENS) (err error) {
@@ -321,10 +321,10 @@ func DB_updateUserDeviceTokens(TU *UPDATE_USER_TOKENS) (err error) {
 			},
 		)
 	if err != nil {
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return err
 }
 
 func DB_updateUserSubTime(u *User) (err error) {
@@ -353,16 +353,16 @@ func DB_updateUserSubTime(u *User) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Could not update user sub time: ", err)
+		ADMIN("Could not update user sub time: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Could not update user sub time: ", err)
+		ADMIN("Could not update user sub time: ", err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_updateUser(UF *USER_UPDATE_FORM) (err error) {
@@ -392,16 +392,16 @@ func DB_updateUser(UF *USER_UPDATE_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Could not update user: ", err)
+		ADMIN("Could not update user: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Could not update user: ", err)
+		ADMIN("Could not update user: ", err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_updateUserAdmin(UF *USER_ADMIN_UPDATE_FORM) (err error) {
@@ -442,16 +442,16 @@ func DB_updateUserAdmin(UF *USER_ADMIN_UPDATE_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Could not admin update user: ", err)
+		ADMIN("Could not admin update user: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Could not admin update user: user not found")
+		ADMIN("Could not admin update user: user not found")
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_toggleUserSubscriptionStatus(UF *USER_UPDATE_SUB_FORM) (err error) {
@@ -480,16 +480,16 @@ func DB_toggleUserSubscriptionStatus(UF *USER_UPDATE_SUB_FORM) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Could not update user sub status: ", err)
+		ADMIN("Could not update user sub status: ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Could not update user sub status: ", err)
+		ADMIN("Could not update user sub status: ", err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_userUpdateTwoFactorCodes(TFP *TWO_FACTOR_DB_PACKAGE) (err error) {
@@ -515,10 +515,10 @@ func DB_userUpdateTwoFactorCodes(TFP *TWO_FACTOR_DB_PACKAGE) (err error) {
 			},
 		)
 	if err != nil {
-		ADMIN( err)
+		ADMIN(err)
 	}
 
-	return
+	return err
 }
 
 func DB_userResetPassword(user *User) error {
@@ -544,12 +544,12 @@ func DB_userResetPassword(user *User) error {
 			},
 		)
 	if err != nil {
-		ADMIN( "Unable to modify user password: ", user.ID)
+		ADMIN("Unable to modify user password: ", user.ID)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to modify user password: ", user.ID)
+		ADMIN("Unable to modify user password: ", user.ID)
 		return errors.New("user password could not be modified")
 	}
 
@@ -582,7 +582,7 @@ func DB_FindServersWithoutGroups(limit, offset int64) (DL []*types.Server, err e
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to find online devices: ", err)
+		ADMIN("Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -591,13 +591,13 @@ func DB_FindServersWithoutGroups(limit, offset int64) (DL []*types.Server, err e
 		D := new(types.Server)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN( "Unable to decode device to struct: ", err)
+			ADMIN("Unable to decode device to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
 	}
 
-	return
+	return DL, err
 }
 
 func DB_FindServersByGroups(groups []primitive.ObjectID, limit, offset int64) (DL []*types.Server, err error) {
@@ -624,7 +624,7 @@ func DB_FindServersByGroups(groups []primitive.ObjectID, limit, offset int64) (D
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to find online devices: ", err)
+		ADMIN("Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -633,13 +633,13 @@ func DB_FindServersByGroups(groups []primitive.ObjectID, limit, offset int64) (D
 		D := new(types.Server)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN( "Unable to decode device to struct: ", err)
+			ADMIN("Unable to decode device to struct: ", err)
 			continue
 		}
 		DL = append(DL, D)
 	}
 
-	return
+	return DL, err
 }
 
 func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offset int64) (IL []any, err error) {
@@ -680,7 +680,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to find online devices: ", err)
+		ADMIN("Unable to find online devices: ", err)
 		return nil, err
 	}
 
@@ -691,7 +691,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(types.Server)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN( "Unable to decode device to struct: ", err)
+				ADMIN("Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
@@ -699,7 +699,7 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(User)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN( "Unable to decode device to struct: ", err)
+				ADMIN("Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
@@ -707,14 +707,14 @@ func DB_FindEntitiesByGroupID(id primitive.ObjectID, objType string, limit, offs
 			E := new(types.Device)
 			err = cursor.Decode(E)
 			if err != nil {
-				ADMIN( "Unable to decode device to struct: ", err)
+				ADMIN("Unable to decode device to struct: ", err)
 				continue
 			}
 			IL = append(IL, E)
 		}
 	}
 
-	return
+	return IL, err
 }
 
 func DB_UpdateGroup(G *Group) (err error) {
@@ -747,15 +747,15 @@ func DB_UpdateGroup(G *Group) (err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN( "Unable to update group", G.ID.Hex(), err)
+		ADMIN("Unable to update group", G.ID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to update group(no match count)", G.ID.Hex(), err)
+		ADMIN("Unable to update group(no match count)", G.ID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_UpdateServer(S *types.Server) (RS *types.Server, err error) {
@@ -789,11 +789,11 @@ func DB_UpdateServer(S *types.Server) (RS *types.Server, err error) {
 			options.FindOneAndUpdate(),
 		).Decode(&RS)
 	if err != nil {
-		ADMIN( "Unable to update server: ", S.ID.Hex())
+		ADMIN("Unable to update server: ", S.ID.Hex())
 		return nil, err
 	}
 
-	return
+	return RS, err
 }
 
 func DB_CreateDevice(D *types.Device) (err error) {
@@ -810,11 +810,11 @@ func DB_CreateDevice(D *types.Device) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN( "Unable to create device: ", err)
+		ADMIN("Unable to create device: ", err)
 		return err
 	}
 
-	return
+	return err
 }
 
 func DB_CreateGroup(G *Group) (err error) {
@@ -831,11 +831,11 @@ func DB_CreateGroup(G *Group) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN( "Unable to create group: ", err)
+		ADMIN("Unable to create group: ", err)
 		return err
 	}
 
-	return
+	return err
 }
 
 func DB_CreateServer(S *types.Server) (err error) {
@@ -852,11 +852,11 @@ func DB_CreateServer(S *types.Server) (err error) {
 			options.InsertOne(),
 		)
 	if err != nil {
-		ADMIN( "Unable to create server: ", err)
+		ADMIN("Unable to create server: ", err)
 		return err
 	}
 
-	return
+	return err
 }
 
 func DB_FindServerByID(ID primitive.ObjectID) (S *types.Server, err error) {
@@ -878,11 +878,11 @@ func DB_FindServerByID(ID primitive.ObjectID) (S *types.Server, err error) {
 			options.FindOne(),
 		).Decode(S)
 	if err != nil {
-		ADMIN( "Could not find server by id: ", ID, " / ", err)
+		ADMIN("Could not find server by id: ", ID, " / ", err)
 		return nil, err
 	}
 
-	return
+	return S, err
 }
 
 func DB_WipeUserConfirmCode(UF *USER_ENABLE_QUERY) (err error) {
@@ -911,17 +911,17 @@ func DB_WipeUserConfirmCode(UF *USER_ENABLE_QUERY) (err error) {
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Could not enable user: ", err)
+		ADMIN("Could not enable user: ", err)
 		return err
 	}
 
 	// INFO( "COUNTS:", res.MatchedCount, res.ModifiedCount)
 	if res.MatchedCount == 0 {
-		ADMIN( "Could not enable user, user no found: ", err)
+		ADMIN("Could not enable user, user no found: ", err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_UserActivateKey(SubExpiration time.Time, Key *LicenseKey, userID primitive.ObjectID) (err error) {
@@ -953,16 +953,16 @@ func DB_UserActivateKey(SubExpiration time.Time, Key *LicenseKey, userID primiti
 			options.Update(),
 		)
 	if err != nil {
-		ADMIN( "Unable to update user post payment: ", userID, " / ", err)
+		ADMIN("Unable to update user post payment: ", userID, " / ", err)
 		return err
 	}
 
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to update user post payment: ", userID)
+		ADMIN("Unable to update user post payment: ", userID)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_AddToGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, objType string) (err error) {
@@ -1010,15 +1010,15 @@ func DB_AddToGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, objTyp
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN( "Unable to update object", objType, typeID.Hex(), err)
+		ADMIN("Unable to update object", objType, typeID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to update (no match count)", objType, typeID.Hex(), err)
+		ADMIN("Unable to update (no match count)", objType, typeID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_RemoveFromGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, objType string) (err error) {
@@ -1066,15 +1066,15 @@ func DB_RemoveFromGroup(groupID primitive.ObjectID, typeID primitive.ObjectID, o
 		if err == mongo.ErrNoDocuments {
 			return nil
 		}
-		ADMIN( "Unable to update object", objType, typeID.Hex(), err)
+		ADMIN("Unable to update object", objType, typeID.Hex(), err)
 		return err
 	}
 	if res.MatchedCount == 0 {
-		ADMIN( "Unable to update (no match count)", objType, typeID.Hex(), err)
+		ADMIN("Unable to update (no match count)", objType, typeID.Hex(), err)
 		return errors.New("unable to modify document")
 	}
 
-	return
+	return err
 }
 
 func DB_FindDeviceByID(id primitive.ObjectID) (dev *types.Device, err error) {
@@ -1098,11 +1098,11 @@ func DB_FindDeviceByID(id primitive.ObjectID) (dev *types.Device, err error) {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
-		ADMIN( "Unable to find device by id :", id, err)
+		ADMIN("Unable to find device by id :", id, err)
 		return nil, err
 	}
 
-	return
+	return dev, err
 }
 
 func DB_findGroupByID(id primitive.ObjectID) (G *Group, err error) {
@@ -1123,11 +1123,11 @@ func DB_findGroupByID(id primitive.ObjectID) (G *Group, err error) {
 			opt,
 		).Decode(&G)
 	if err != nil {
-		ADMIN( "Unable to find group by id: ", id, err)
+		ADMIN("Unable to find group by id: ", id, err)
 		return nil, err
 	}
 
-	return
+	return G, err
 }
 
 func DB_DeleteGroupByID(id primitive.ObjectID) (err error) {
@@ -1147,11 +1147,11 @@ func DB_DeleteGroupByID(id primitive.ObjectID) (err error) {
 			opt,
 		)
 	if err != nil {
-		ADMIN( "Unable to delete group by id: ", id, err)
+		ADMIN("Unable to delete group by id: ", id, err)
 		return err
 	}
 
-	return
+	return err
 }
 
 func DB_findGroups() (gl []*Group, err error) {
@@ -1170,7 +1170,7 @@ func DB_findGroups() (gl []*Group, err error) {
 		opt,
 	)
 	if err != nil {
-		ADMIN( "Unable to find groups: ", err)
+		ADMIN("Unable to find groups: ", err)
 		return nil, err
 	}
 
@@ -1179,11 +1179,11 @@ func DB_findGroups() (gl []*Group, err error) {
 		D := new(Group)
 		err = cursor.Decode(D)
 		if err != nil {
-			ADMIN( "Unable to decode group to struct: ", err)
+			ADMIN("Unable to decode group to struct: ", err)
 			continue
 		}
 		gl = append(gl, D)
 	}
 
-	return
+	return gl, err
 }

--- a/server/dhcp.go
+++ b/server/dhcp.go
@@ -25,7 +25,7 @@ func generateDHCPMap() (err error) {
 		index++
 	}
 
-	return
+	return err
 }
 
 func assignDHCP(CR *types.ControllerConnectRequest, CRR *types.ServerConnectResponse, index int) (err error) {
@@ -87,7 +87,7 @@ func assignDHCP(CR *types.ControllerConnectRequest, CRR *types.ServerConnectResp
 		return errors.New("No DHCP ip address available")
 	}
 
-	return
+	return err
 }
 
 func inc(ip net.IP) {

--- a/server/encrypt_test.go
+++ b/server/encrypt_test.go
@@ -249,9 +249,9 @@ func TestEncryptDecryptWithDifferentPasswordLengths(t *testing.T) {
 	plaintext := "Test message for different password lengths"
 
 	passwords := [][]byte{
-		[]byte("a"),                           // 1 byte
-		[]byte("short"),                       // 5 bytes
-		[]byte("medium-password"),             // 15 bytes
+		[]byte("a"),                          // 1 byte
+		[]byte("short"),                      // 5 bytes
+		[]byte("medium-password"),            // 15 bytes
 		[]byte("a-longer-password-for-test"), // 27 bytes
 		[]byte(strings.Repeat("x", 100)),     // 100 bytes
 	}

--- a/server/firewall.go
+++ b/server/firewall.go
@@ -32,7 +32,6 @@ func syncFirewallState(fr *types.FirewallRequest, mapping *UserCoreMapping) {
 				found = true
 				break
 			}
-
 		}
 
 		if !found {
@@ -77,7 +76,7 @@ func getIP4FromHostOrDHCP(host string) (ip4 [4]byte, ok bool) {
 	} else {
 		ip4, ok = getHostnameFromDHCP(host)
 	}
-	return
+	return ip4, ok
 }
 
 func getHostnameFromDHCP(hostname string) (ip4b [4]byte, ok bool) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -377,7 +377,6 @@ func API_UserTwoFactorConfirm(w http.ResponseWriter, r *http.Request) {
 			senderr(w, 401, "Invalid Recovery code")
 			return
 		}
-
 	} else {
 		if user.TwoFactorEnabled {
 			senderr(w, 401, "This account already has two factor authentication enabled")
@@ -491,7 +490,7 @@ func API_DeviceUpdate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_UpdateDevice(F.Device)
 	if err != nil {
-		ERR( err)
+		ERR(err)
 		senderr(w, 500, "Unknown error, please try again in a moment")
 		return
 	}
@@ -587,7 +586,6 @@ func API_DeviceCreate(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-
 	}
 
 	if F.Device == nil || F.Device.Tag == "" {
@@ -603,7 +601,7 @@ func API_DeviceCreate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_CreateDevice(F.Device)
 	if err != nil {
-		ERR( err)
+		ERR(err)
 		senderr(w, 500, "Unable to create group, please try again later")
 		return
 	}
@@ -643,7 +641,7 @@ func API_GroupCreate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_CreateGroup(F.Group)
 	if err != nil {
-		ERR( err)
+		ERR(err)
 		senderr(w, 500, "Unable to create group, please try again later")
 		return
 	}
@@ -780,7 +778,7 @@ func API_GroupUpdate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_UpdateGroup(F.Group)
 	if err != nil {
-		ERR( err)
+		ERR(err)
 		senderr(w, 500, "Unknown error, please try again in a moment")
 		return
 	}
@@ -1308,7 +1306,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	INFO( "KEY attempt:", AF.Key)
+	INFO("KEY attempt:", AF.Key)
 
 	lemonClient := lc.Load()
 	key, resp, err := lemonClient.Licenses.Validate(context.Background(), AF.Key, "")
@@ -1334,7 +1332,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 			user.SubExpiration = time.Now()
 		}
 		user.SubExpiration = user.SubExpiration.AddDate(0, 1, 0).Add(time.Duration(rand.Intn(60)+60) * time.Minute)
-		INFO( "KEY +1:", key.LicenseKey.Key, " - check activation in lemon")
+		INFO("KEY +1:", key.LicenseKey.Key, " - check activation in lemon")
 
 		user.Key = &LicenseKey{
 			Created: key.LicenseKey.CreatedAt,
@@ -1345,14 +1343,14 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 		ns := strings.Split(key.Meta.ProductName, " ")
 		months, err := strconv.Atoi(ns[0])
 		if err != nil {
-			ADMIN( "unable to parse license key name:", err)
+			ADMIN("unable to parse license key name:", err)
 			senderr(w, 500, "Something went wrong, please contact customer support")
 		}
 		if user.SubExpiration.IsZero() {
 			user.SubExpiration = time.Now()
 		}
 		user.SubExpiration = time.Now().AddDate(0, months, 0).Add(time.Duration(rand.Intn(600)+60) * time.Minute)
-		INFO( "KEY +", months, ":", key.LicenseKey.Key, " - check activate in lemon")
+		INFO("KEY +", months, ":", key.LicenseKey.Key, " - check activate in lemon")
 
 		user.Key = &LicenseKey{
 			Created: key.LicenseKey.CreatedAt,
@@ -1385,7 +1383,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if key != nil {
-		INFO( "KEY: Activated:", key.LicenseKey.Key)
+		INFO("KEY: Activated:", key.LicenseKey.Key)
 	}
 
 	w.WriteHeader(200)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -491,7 +491,7 @@ func API_DeviceUpdate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_UpdateDevice(F.Device)
 	if err != nil {
-		ERR(3, err)
+		ERR( err)
 		senderr(w, 500, "Unknown error, please try again in a moment")
 		return
 	}
@@ -603,7 +603,7 @@ func API_DeviceCreate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_CreateDevice(F.Device)
 	if err != nil {
-		ERR(3, err)
+		ERR( err)
 		senderr(w, 500, "Unable to create group, please try again later")
 		return
 	}
@@ -643,7 +643,7 @@ func API_GroupCreate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_CreateGroup(F.Group)
 	if err != nil {
-		ERR(3, err)
+		ERR( err)
 		senderr(w, 500, "Unable to create group, please try again later")
 		return
 	}
@@ -780,7 +780,7 @@ func API_GroupUpdate(w http.ResponseWriter, r *http.Request) {
 
 	err = DB_UpdateGroup(F.Group)
 	if err != nil {
-		ERR(3, err)
+		ERR( err)
 		senderr(w, 500, "Unknown error, please try again in a moment")
 		return
 	}
@@ -1308,7 +1308,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	INFO(3, "KEY attempt:", AF.Key)
+	INFO( "KEY attempt:", AF.Key)
 
 	lemonClient := lc.Load()
 	key, resp, err := lemonClient.Licenses.Validate(context.Background(), AF.Key, "")
@@ -1334,7 +1334,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 			user.SubExpiration = time.Now()
 		}
 		user.SubExpiration = user.SubExpiration.AddDate(0, 1, 0).Add(time.Duration(rand.Intn(60)+60) * time.Minute)
-		INFO(3, "KEY +1:", key.LicenseKey.Key, " - check activation in lemon")
+		INFO( "KEY +1:", key.LicenseKey.Key, " - check activation in lemon")
 
 		user.Key = &LicenseKey{
 			Created: key.LicenseKey.CreatedAt,
@@ -1345,14 +1345,14 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 		ns := strings.Split(key.Meta.ProductName, " ")
 		months, err := strconv.Atoi(ns[0])
 		if err != nil {
-			ADMIN(3, "unable to parse license key name:", err)
+			ADMIN( "unable to parse license key name:", err)
 			senderr(w, 500, "Something went wrong, please contact customer support")
 		}
 		if user.SubExpiration.IsZero() {
 			user.SubExpiration = time.Now()
 		}
 		user.SubExpiration = time.Now().AddDate(0, months, 0).Add(time.Duration(rand.Intn(600)+60) * time.Minute)
-		INFO(3, "KEY +", months, ":", key.LicenseKey.Key, " - check activate in lemon")
+		INFO( "KEY +", months, ":", key.LicenseKey.Key, " - check activate in lemon")
 
 		user.Key = &LicenseKey{
 			Created: key.LicenseKey.CreatedAt,
@@ -1385,7 +1385,7 @@ func API_ActivateLicenseKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if key != nil {
-		INFO(3, "KEY: Activated:", key.LicenseKey.Key)
+		INFO( "KEY: Activated:", key.LicenseKey.Key)
 	}
 
 	w.WriteHeader(200)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -360,14 +360,13 @@ func API_UserTwoFactorConfirm(w http.ResponseWriter, r *http.Request) {
 		recoveryFound := false
 		recoveryUpper := strings.ToUpper(LF.Recovery)
 		rc, err := Decrypt(user.RecoveryCodes, []byte(loadSecret("TwoFactorKey")))
-		// rc, err := encrypter.Decrypt(user.RecoveryCodes, []byte(ENV.F2KEY))
 		if err != nil {
 			ADMIN(err)
 			senderr(w, 500, "Encryption error")
 			return
 		}
 
-		rcs := strings.SplitSeq(string(rc), " ")
+		rcs := strings.SplitSeq(rc, " ")
 		for v := range rcs {
 			if v == recoveryUpper {
 				recoveryFound = true
@@ -1248,7 +1247,7 @@ func API_UserResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	otp := gotp.NewDefaultTOTP(string(code)).Now()
+	otp := gotp.NewDefaultTOTP(code).Now()
 	if otp != RF.ResetCode {
 		return
 	}

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -25,7 +25,7 @@ func BasicRecover() {
 func CopySlice(in []byte) (out []byte) {
 	out = make([]byte, len(in))
 	_ = copy(out, in)
-	return
+	return out
 }
 
 var letterRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
@@ -97,7 +97,7 @@ func handleUserDeviceToken(user *User, LF *LOGIN_FORM) (userTokenUpdate *UPDATE_
 	userTokenUpdate.Tokens = user.Tokens
 	userTokenUpdate.Version = LF.Version
 
-	return
+	return userTokenUpdate
 }
 
 func validateUserTwoFactor(user *User, LF *LOGIN_FORM) (err error) {
@@ -109,7 +109,6 @@ func validateUserTwoFactor(user *User, LF *LOGIN_FORM) (err error) {
 	}()
 	recoveryEnabled := false
 	if user.TwoFactorEnabled {
-
 		if LF.Recovery != "" {
 			recoveryFound := false
 			recoveryUpper := strings.ToUpper(LF.Recovery)
@@ -180,7 +179,7 @@ func authenticateUserFromEmailOrIDAndToken(email string, id primitive.ObjectID, 
 	}
 
 	if allowed {
-		return
+		return user, err
 	}
 
 	return nil, errors.New("unauthorized")

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -119,7 +119,7 @@ func validateUserTwoFactor(user *User, LF *LOGIN_FORM) (err error) {
 				return errors.New("encryption error")
 			}
 
-			rcs := strings.SplitSeq(string(rc), " ")
+			rcs := strings.SplitSeq(rc, " ")
 			for v := range rcs {
 				if v == recoveryUpper {
 					recoveryEnabled = true
@@ -139,7 +139,7 @@ func validateUserTwoFactor(user *User, LF *LOGIN_FORM) (err error) {
 				return errors.New("encryption error")
 			}
 
-			otp := gotp.NewDefaultTOTP(string(code)).Now()
+			otp := gotp.NewDefaultTOTP(code).Now()
 			if otp != LF.Digits {
 				return errors.New("Authenticator code was incorrect")
 			}

--- a/server/helpers_test.go
+++ b/server/helpers_test.go
@@ -113,11 +113,6 @@ func TestGENERATE_CODE(t *testing.T) {
 			}
 		}
 
-		// Test 3: Code should be uppercase
-		if code != code {
-			t.Errorf("GENERATE_CODE produced code with lowercase characters: %s", code)
-		}
-
 		// Store for uniqueness test
 		codes[code] = true
 	}

--- a/server/logging.go
+++ b/server/logging.go
@@ -39,7 +39,7 @@ func buildOut(x ...any) (out string) {
 	for _, v := range x {
 		out += fmt.Sprint(v)
 	}
-	return
+	return out
 }
 
 func getLogLevelInt(level string) int {

--- a/server/logging.go
+++ b/server/logging.go
@@ -1,0 +1,53 @@
+package main
+
+import "fmt"
+
+// LOG ...
+func LOG(x ...any) {
+	logger.Info("INFO", "msg", buildOut(x))
+}
+
+// INFO ...
+func INFO(x ...any) {
+	logger.Info("INFO", "msg", buildOut(x))
+}
+
+// WARN ...
+func WARN(x ...any) {
+	logger.Warn("WARN", "msg", buildOut(x))
+}
+
+// ERR ...
+func ERR(x ...any) {
+	logger.Error("ERROR", "msg", buildOut(x))
+}
+
+// ADMIN ...
+func ADMIN(x ...any) {
+	logger.Warn("ADMIN", "msg", buildOut(x))
+}
+
+// buildOut ...
+// we will eventually replace this and the calling functions
+// with something better
+func buildOut(x ...any) (out string) {
+	for _, v := range x {
+		out += fmt.Sprint(v)
+	}
+	return
+}
+
+func getLogLevelInt(level string) int {
+	switch level {
+	case "debug":
+		return -4
+	case "info":
+		return 0
+	case "warn":
+		return 4
+	case "error":
+		return 8
+	default:
+		return -4
+	}
+}

--- a/server/logging.go
+++ b/server/logging.go
@@ -1,6 +1,11 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+)
 
 // LOG ...
 func LOG(x ...any) {
@@ -50,4 +55,28 @@ func getLogLevelInt(level string) int {
 	default:
 		return -4
 	}
+}
+
+func initLogging(silent, jsonLogs, sourceInfo bool, logLevel string) {
+	var logHandler slog.Handler
+	slogConfig := &slog.HandlerOptions{
+		Level:     slog.Level(getLogLevelInt(logLevel)),
+		AddSource: sourceInfo,
+	}
+	if !silent {
+		if !jsonLogs {
+			logHandler = slog.NewTextHandler(os.Stdout, slogConfig)
+		} else {
+			logHandler = slog.NewJSONHandler(os.Stdout, slogConfig)
+		}
+	} else if silent {
+		disableLogs = true
+		if !jsonLogs {
+			logHandler = slog.NewTextHandler(io.Discard, slogConfig)
+		} else {
+			logHandler = slog.NewJSONHandler(io.Discard, slogConfig)
+		}
+	}
+	logger = slog.New(logHandler)
+	slog.SetDefault(logger)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -78,31 +78,26 @@ var (
 )
 
 // LOG ...
-// deprecated, will be phased out slowly
 func LOG(x ...any) {
 	logger.Info("INFO", "msg", buildOut(x))
 }
 
 // INFO ...
-// deprecated, will be phased out slowly
 func INFO(x ...any) {
 	logger.Info("INFO", "msg", buildOut(x))
 }
 
 // WARN ...
-// deprecated, will be phased out slowly
 func WARN(x ...any) {
 	logger.Warn("WARN", "msg", buildOut(x))
 }
 
 // ERR ...
-// deprecated, will be phased out slowly
 func ERR(x ...any) {
 	logger.Error("ERROR", "msg", buildOut(x))
 }
 
 // ADMIN ...
-// deprecated, will be phased out slowly
 func ADMIN(x ...any) {
 	logger.Warn("ADMIN", "msg", buildOut(x))
 }

--- a/server/main.go
+++ b/server/main.go
@@ -114,6 +114,7 @@ func main() {
 	silent := flag.Bool("silent", false, "This command disables logging")
 	adminFlag := flag.String("admin", "", "Add an admin identifier (DeviceToken/DeviceKey/UserID) to NetAdmins")
 	flag.Parse()
+
 	var logHandler slog.Handler
 	if !*silent {
 		if !*jsonLogs {

--- a/server/main.go
+++ b/server/main.go
@@ -90,27 +90,7 @@ func main() {
 	adminFlag := flag.String("admin", "", "Add an admin identifier (DeviceToken/DeviceKey/UserID) to NetAdmins")
 	flag.Parse()
 
-	var logHandler slog.Handler
-	slogConfig := &slog.HandlerOptions{
-		Level:     slog.Level(getLogLevelInt(*logLevel)),
-		AddSource: *sourceInfo,
-	}
-	if !*silent {
-		if !*jsonLogs {
-			logHandler = slog.NewTextHandler(os.Stdout, slogConfig)
-		} else {
-			logHandler = slog.NewJSONHandler(os.Stdout, slogConfig)
-		}
-	} else if *silent {
-		disableLogs = true
-		if !*jsonLogs {
-			logHandler = slog.NewTextHandler(io.Discard, slogConfig)
-		} else {
-			logHandler = slog.NewJSONHandler(io.Discard, slogConfig)
-		}
-	}
-	logger = slog.New(logHandler)
-	slog.SetDefault(logger)
+	initLogging(*silent, *jsonLogs, *sourceInfo, *logLevel)
 
 	if showVersion {
 		fmt.Println(version.Version)

--- a/server/main.go
+++ b/server/main.go
@@ -165,7 +165,6 @@ func main() {
 				logger.Error("unable to connect to bbolt", slog.Any("err", err))
 				os.Exit(1)
 			}
-
 		} else {
 			err = ConnectToDB(loadSecret("DBurl"))
 			if err != nil {
@@ -258,7 +257,7 @@ func LoadServerConfig(path string) (err error) {
 	var nb []byte
 	nb, err = os.ReadFile(path)
 	if err != nil {
-		return
+		return err
 	}
 	C := new(types.ServerConfig)
 
@@ -274,14 +273,14 @@ func LoadServerConfig(path string) (err error) {
 	}
 
 	if err != nil {
-		return
+		return err
 	}
 	err = validateConfig(C)
 	if err != nil {
-		return
+		return err
 	}
 	Config.Store(C)
-	return
+	return err
 }
 
 func SaveServerConfig(path string) (err error) {
@@ -323,7 +322,7 @@ func addAdminToConfig(identifier string) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	hashedIdentifier := HashIdentifier(identifier)
+	hashedIdentifier := hashIdentifier(identifier)
 
 	C := Config.Load()
 	C.NetAdmins = append(C.NetAdmins, hashedIdentifier)
@@ -454,14 +453,14 @@ func initializeVPN() {
 func initializeLAN() (err error) {
 	err = generateDHCPMap()
 	if err != nil {
-		return
+		return err
 	}
 	Config := Config.Load()
 
 	if Config.Lan != nil {
 		lanFirewallDisabled = Config.DisableLanFirewall
 	}
-	return
+	return err
 }
 
 func GenerateVPLCoreMappings() {
@@ -497,7 +496,6 @@ func GeneratePortAllocation() (err error) {
 		PR.EndPort = PR.StartPort + uint16(portPerUser)
 
 		for i := PR.StartPort; i <= PR.EndPort; i++ {
-
 			if i < PR.StartPort {
 				return errors.New("start port is too small")
 			} else if i > PR.EndPort {
@@ -608,7 +606,7 @@ func makeCerts(execPath string, IP string) (err error) {
 		time.Time{},
 		true,
 	)
-	return
+	return err
 }
 
 func makeCertsOnly() (err error) {

--- a/server/main.go
+++ b/server/main.go
@@ -143,10 +143,11 @@ func main() {
 
 	AUTHEnabled = slices.Contains(config.Features, types.AUTH)
 	LANEnabled = slices.Contains(config.Features, types.LAN)
-	// In development
-	// DNSEnabled = slices.Contains(config.Features, types.DNS)
 	VPNEnabled = slices.Contains(config.Features, types.VPN)
 	BBOLTEnabled = slices.Contains(config.Features, types.BBOLT)
+
+	// In development
+	// DNSEnabled = slices.Contains(config.Features, types.DNS)
 
 	err = loadCertificatesAndTLSSettings()
 	if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -77,22 +77,32 @@ var (
 	lc atomic.Pointer[lemonsqueezy.Client]
 )
 
+// LOG ...
+// deprecated, will be phased out slowly
 func LOG(x ...any) {
 	logger.Info("INFO", "msg", buildOut(x))
 }
 
+// INFO ...
+// deprecated, will be phased out slowly
 func INFO(x ...any) {
 	logger.Info("INFO", "msg", buildOut(x))
 }
 
+// WARN ...
+// deprecated, will be phased out slowly
 func WARN(x ...any) {
 	logger.Warn("WARN", "msg", buildOut(x))
 }
 
+// ERR ...
+// deprecated, will be phased out slowly
 func ERR(x ...any) {
 	logger.Error("ERROR", "msg", buildOut(x))
 }
 
+// ADMIN ...
+// deprecated, will be phased out slowly
 func ADMIN(x ...any) {
 	logger.Warn("ADMIN", "msg", buildOut(x))
 }

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tunnels-is/tunnels/types"
+	"gopkg.in/yaml.v3"
 )
 
 func Test_validateConfig(t *testing.T) {
@@ -11,19 +16,19 @@ func Test_validateConfig(t *testing.T) {
 		name           string
 		config         *types.ServerConfig
 		expectError    bool
-		expectedValues map[string]interface{}
+		expectedValues map[string]any
 	}{
 		{
 			name: "valid config with all fields set",
 			config: &types.ServerConfig{
-				UserMaxConnections:  5,
-				PingTimeoutMinutes:  10,
-				DHCPTimeoutHours:    24,
-				Features:            []types.Feature{types.VPN, types.LAN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 5,
+				PingTimeoutMinutes: 10,
+				DHCPTimeoutHours:   24,
+				Features:           []types.Feature{types.VPN, types.LAN},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"UserMaxConnections": 5,
 				"PingTimeoutMinutes": 10,
 				"DHCPTimeoutHours":   24,
@@ -32,92 +37,92 @@ func Test_validateConfig(t *testing.T) {
 		{
 			name: "UserMaxConnections < 1 - should default to 2",
 			config: &types.ServerConfig{
-				UserMaxConnections:  0,
-				PingTimeoutMinutes:  5,
-				DHCPTimeoutHours:    12,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 0,
+				PingTimeoutMinutes: 5,
+				DHCPTimeoutHours:   12,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"UserMaxConnections": 2,
 			},
 		},
 		{
 			name: "PingTimeoutMinutes < 2 - should default to 2",
 			config: &types.ServerConfig{
-				UserMaxConnections:  3,
-				PingTimeoutMinutes:  1,
-				DHCPTimeoutHours:    12,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 3,
+				PingTimeoutMinutes: 1,
+				DHCPTimeoutHours:   12,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"PingTimeoutMinutes": 2,
 			},
 		},
 		{
 			name: "DHCPTimeoutHours < 1 - should default to 1",
 			config: &types.ServerConfig{
-				UserMaxConnections:  3,
-				PingTimeoutMinutes:  5,
-				DHCPTimeoutHours:    0,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 3,
+				PingTimeoutMinutes: 5,
+				DHCPTimeoutHours:   0,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"DHCPTimeoutHours": 1,
 			},
 		},
 		{
 			name: "no features - should error",
 			config: &types.ServerConfig{
-				UserMaxConnections:  3,
-				PingTimeoutMinutes:  5,
-				DHCPTimeoutHours:    12,
-				Features:            []types.Feature{},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 3,
+				PingTimeoutMinutes: 5,
+				DHCPTimeoutHours:   12,
+				Features:           []types.Feature{},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: true,
 		},
 		{
 			name: "nil features - should error",
 			config: &types.ServerConfig{
-				UserMaxConnections:  3,
-				PingTimeoutMinutes:  5,
-				DHCPTimeoutHours:    12,
-				Features:            nil,
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 3,
+				PingTimeoutMinutes: 5,
+				DHCPTimeoutHours:   12,
+				Features:           nil,
+				SecretStore:        types.EnvStore,
 			},
 			expectError: true,
 		},
 		{
 			name: "empty SecretStore - should default to EnvStore",
 			config: &types.ServerConfig{
-				UserMaxConnections:  3,
-				PingTimeoutMinutes:  5,
-				DHCPTimeoutHours:    12,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         "",
+				UserMaxConnections: 3,
+				PingTimeoutMinutes: 5,
+				DHCPTimeoutHours:   12,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        "",
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"SecretStore": types.EnvStore,
 			},
 		},
 		{
 			name: "multiple defaults triggered",
 			config: &types.ServerConfig{
-				UserMaxConnections:  0,
-				PingTimeoutMinutes:  0,
-				DHCPTimeoutHours:    0,
-				Features:            []types.Feature{types.VPN, types.LAN, types.AUTH},
-				SecretStore:         "",
+				UserMaxConnections: 0,
+				PingTimeoutMinutes: 0,
+				DHCPTimeoutHours:   0,
+				Features:           []types.Feature{types.VPN, types.LAN, types.AUTH},
+				SecretStore:        "",
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"UserMaxConnections": 2,
 				"PingTimeoutMinutes": 2,
 				"DHCPTimeoutHours":   1,
@@ -127,14 +132,14 @@ func Test_validateConfig(t *testing.T) {
 		{
 			name: "negative values should trigger defaults",
 			config: &types.ServerConfig{
-				UserMaxConnections:  -5,
-				PingTimeoutMinutes:  -10,
-				DHCPTimeoutHours:    -24,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: -5,
+				PingTimeoutMinutes: -10,
+				DHCPTimeoutHours:   -24,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        types.EnvStore,
 			},
 			expectError: false,
-			expectedValues: map[string]interface{}{
+			expectedValues: map[string]any{
 				"UserMaxConnections": 2,
 				"PingTimeoutMinutes": 2,
 				"DHCPTimeoutHours":   1,
@@ -162,7 +167,7 @@ func Test_validateConfig(t *testing.T) {
 
 			// Check expected values
 			for key, expected := range tc.expectedValues {
-				var actual interface{}
+				var actual any
 				switch key {
 				case "UserMaxConnections":
 					actual = tc.config.UserMaxConnections
@@ -225,11 +230,11 @@ func Test_validateConfig_BoundaryValues(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			config := &types.ServerConfig{
-				UserMaxConnections:  10,
-				PingTimeoutMinutes:  10,
-				DHCPTimeoutHours:    10,
-				Features:            []types.Feature{types.VPN},
-				SecretStore:         types.EnvStore,
+				UserMaxConnections: 10,
+				PingTimeoutMinutes: 10,
+				DHCPTimeoutHours:   10,
+				Features:           []types.Feature{types.VPN},
+				SecretStore:        types.EnvStore,
 			}
 
 			// Set the specific field to test
@@ -263,6 +268,559 @@ func Test_validateConfig_BoundaryValues(t *testing.T) {
 			}
 
 			t.Logf("%s=%d validated correctly ✓", tc.field, tc.value)
+		})
+	}
+}
+
+func Test_LoadServerConfig_JSON(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	testConfig := &types.ServerConfig{
+		UserMaxConnections: 5,
+		PingTimeoutMinutes: 10,
+		DHCPTimeoutHours:   24,
+		Features:           []types.Feature{types.VPN, types.LAN, types.AUTH},
+		SecretStore:        types.EnvStore,
+		VPNIP:              "192.168.1.1",
+		VPNPort:            "444",
+		APIPort:            "443",
+		Hostname:           "test.local",
+	}
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "load valid JSON config",
+			filename:    "config.json",
+			expectError: false,
+		},
+		{
+			name:        "load JSON without extension",
+			filename:    "config",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Write test config to file
+			data, err := json.MarshalIndent(testConfig, "", "    ")
+			if err != nil {
+				t.Fatalf("Failed to marshal test config: %v", err)
+			}
+
+			if err := os.WriteFile(configPath, data, 0o644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			// Test loading
+			err = LoadServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else {
+					t.Logf("Got expected error: %v ✓", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify loaded config
+			loaded := Config.Load()
+			if loaded.VPNIP != testConfig.VPNIP {
+				t.Errorf("VPNIP: got %s, expected %s", loaded.VPNIP, testConfig.VPNIP)
+			}
+			if loaded.VPNPort != testConfig.VPNPort {
+				t.Errorf("VPNPort: got %s, expected %s", loaded.VPNPort, testConfig.VPNPort)
+			}
+			if len(loaded.Features) != len(testConfig.Features) {
+				t.Errorf("Features length: got %d, expected %d", len(loaded.Features), len(testConfig.Features))
+			}
+
+			t.Log("JSON config loaded successfully ✓")
+		})
+	}
+}
+
+func Test_LoadServerConfig_YAML(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	testConfig := &types.ServerConfig{
+		UserMaxConnections: 5,
+		PingTimeoutMinutes: 10,
+		DHCPTimeoutHours:   24,
+		Features:           []types.Feature{types.VPN, types.LAN, types.AUTH},
+		SecretStore:        types.EnvStore,
+		VPNIP:              "192.168.1.1",
+		VPNPort:            "444",
+		APIPort:            "443",
+		Hostname:           "test.local",
+	}
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "load valid YAML config with .yaml extension",
+			filename:    "config.yaml",
+			expectError: false,
+		},
+		{
+			name:        "load valid YAML config with .yml extension",
+			filename:    "config.yml",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Write test config to file
+			data, err := yaml.Marshal(testConfig)
+			if err != nil {
+				t.Fatalf("Failed to marshal test config: %v", err)
+			}
+
+			if err := os.WriteFile(configPath, data, 0o644); err != nil {
+				t.Fatalf("Failed to write test config: %v", err)
+			}
+
+			// Test loading
+			err = LoadServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else {
+					t.Logf("Got expected error: %v ✓", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify loaded config
+			loaded := Config.Load()
+			if loaded.VPNIP != testConfig.VPNIP {
+				t.Errorf("VPNIP: got %s, expected %s", loaded.VPNIP, testConfig.VPNIP)
+			}
+			if loaded.VPNPort != testConfig.VPNPort {
+				t.Errorf("VPNPort: got %s, expected %s", loaded.VPNPort, testConfig.VPNPort)
+			}
+			if len(loaded.Features) != len(testConfig.Features) {
+				t.Errorf("Features length: got %d, expected %d", len(loaded.Features), len(testConfig.Features))
+			}
+
+			t.Logf("YAML config (%s) loaded successfully ✓", tc.filename)
+		})
+	}
+}
+
+func Test_LoadServerConfig_Errors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		setupFunc   func() string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "unsupported file format",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "config.xml")
+				_ = os.WriteFile(path, []byte("<config></config>"), 0o644)
+				return path
+			},
+			expectError: true,
+			errorMsg:    "unsupported config file format",
+		},
+		{
+			name: "file does not exist",
+			setupFunc: func() string {
+				return filepath.Join(tmpDir, "nonexistent.json")
+			},
+			expectError: true,
+			errorMsg:    "no such file or directory",
+		},
+		{
+			name: "invalid JSON content",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "invalid.json")
+				_ = os.WriteFile(path, []byte("{invalid json}"), 0o644)
+				return path
+			},
+			expectError: true,
+			errorMsg:    "invalid character",
+		},
+		{
+			name: "invalid YAML content",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "invalid.yaml")
+				_ = os.WriteFile(path, []byte("invalid:\n  yaml:\n    - [unclosed"), 0o644)
+				return path
+			},
+			expectError: true,
+		},
+		{
+			name: "config with no features",
+			setupFunc: func() string {
+				path := filepath.Join(tmpDir, "nofeatures.json")
+				cfg := &types.ServerConfig{
+					UserMaxConnections: 5,
+					PingTimeoutMinutes: 10,
+					DHCPTimeoutHours:   24,
+					Features:           []types.Feature{},
+					SecretStore:        types.EnvStore,
+				}
+				data, _ := json.Marshal(cfg)
+				_ = os.WriteFile(path, data, 0o644)
+				return path
+			},
+			expectError: true,
+			errorMsg:    "no features enbaled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := tc.setupFunc()
+			err := LoadServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else {
+					t.Logf("Got expected error: %v ✓", err)
+					if tc.errorMsg != "" && !strings.Contains(err.Error(), tc.errorMsg) {
+						t.Logf("Warning: expected error message to contain '%s', got '%s'", tc.errorMsg, err.Error())
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func Test_SaveServerConfig_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testConfig := &types.ServerConfig{
+		UserMaxConnections: 5,
+		PingTimeoutMinutes: 10,
+		DHCPTimeoutHours:   24,
+		Features:           []types.Feature{types.VPN, types.LAN, types.AUTH},
+		SecretStore:        types.EnvStore,
+		VPNIP:              "192.168.1.1",
+		VPNPort:            "444",
+		APIPort:            "443",
+		Hostname:           "test.local",
+	}
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "save JSON config",
+			filename:    "output.json",
+			expectError: false,
+		},
+		{
+			name:        "save config without extension (defaults to JSON)",
+			filename:    "output",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Store test config
+			Config.Store(testConfig)
+
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Test saving
+			err := SaveServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify file was created
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				t.Error("Config file was not created")
+				return
+			}
+
+			// Load and verify content
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Errorf("Failed to read saved config: %v", err)
+				return
+			}
+
+			var loaded types.ServerConfig
+			if err := json.Unmarshal(data, &loaded); err != nil {
+				t.Errorf("Failed to unmarshal saved config: %v", err)
+				return
+			}
+
+			if loaded.VPNIP != testConfig.VPNIP {
+				t.Errorf("VPNIP: got %s, expected %s", loaded.VPNIP, testConfig.VPNIP)
+			}
+
+			t.Log("JSON config saved successfully ✓")
+		})
+	}
+}
+
+func Test_SaveServerConfig_YAML(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testConfig := &types.ServerConfig{
+		UserMaxConnections: 5,
+		PingTimeoutMinutes: 10,
+		DHCPTimeoutHours:   24,
+		Features:           []types.Feature{types.VPN, types.LAN, types.AUTH},
+		SecretStore:        types.EnvStore,
+		VPNIP:              "192.168.1.1",
+		VPNPort:            "444",
+		APIPort:            "443",
+		Hostname:           "test.local",
+	}
+
+	tests := []struct {
+		name        string
+		filename    string
+		expectError bool
+	}{
+		{
+			name:        "save YAML config with .yaml extension",
+			filename:    "output.yaml",
+			expectError: false,
+		},
+		{
+			name:        "save YAML config with .yml extension",
+			filename:    "output.yml",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Store test config
+			Config.Store(testConfig)
+
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Test saving
+			err := SaveServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Verify file was created
+			if _, err := os.Stat(configPath); os.IsNotExist(err) {
+				t.Error("Config file was not created")
+				return
+			}
+
+			// Load and verify content
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Errorf("Failed to read saved config: %v", err)
+				return
+			}
+
+			var loaded types.ServerConfig
+			if err := yaml.Unmarshal(data, &loaded); err != nil {
+				t.Errorf("Failed to unmarshal saved config: %v", err)
+				return
+			}
+
+			if loaded.VPNIP != testConfig.VPNIP {
+				t.Errorf("VPNIP: got %s, expected %s", loaded.VPNIP, testConfig.VPNIP)
+			}
+
+			t.Logf("YAML config (%s) saved successfully ✓", tc.filename)
+		})
+	}
+}
+
+func Test_SaveServerConfig_Errors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testConfig := &types.ServerConfig{
+		UserMaxConnections: 5,
+		PingTimeoutMinutes: 10,
+		DHCPTimeoutHours:   24,
+		Features:           []types.Feature{types.VPN, types.LAN},
+		SecretStore:        types.EnvStore,
+	}
+
+	tests := []struct {
+		name        string
+		setupFunc   func() string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "unsupported file format",
+			setupFunc: func() string {
+				return filepath.Join(tmpDir, "config.xml")
+			},
+			expectError: true,
+			errorMsg:    "unsupported config file format",
+		},
+		{
+			name: "invalid directory path",
+			setupFunc: func() string {
+				return filepath.Join(tmpDir, "nonexistent", "subdir", "config.json")
+			},
+			expectError: true,
+			errorMsg:    "no such file or directory",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			Config.Store(testConfig)
+			configPath := tc.setupFunc()
+			err := SaveServerConfig(configPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else {
+					t.Logf("Got expected error: %v ✓", err)
+					if tc.errorMsg != "" && !strings.Contains(err.Error(), tc.errorMsg) {
+						t.Logf("Warning: expected error message to contain '%s', got '%s'", tc.errorMsg, err.Error())
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func Test_LoadAndSaveServerConfig_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalConfig := &types.ServerConfig{
+		UserMaxConnections:  7,
+		PingTimeoutMinutes:  15,
+		DHCPTimeoutHours:    48,
+		Features:            []types.Feature{types.VPN, types.LAN, types.AUTH, types.DNS},
+		SecretStore:         types.EnvStore,
+		VPNIP:               "10.0.0.1",
+		VPNPort:             "8444",
+		APIPort:             "8443",
+		Hostname:            "roundtrip.test",
+		StartPort:           2000,
+		EndPort:             65530,
+		InternetAccess:      true,
+		LocalNetworkAccess:  false,
+		ServerBandwidthMbps: 1000,
+		UserBandwidthMbps:   100,
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "JSON round trip",
+			filename: "roundtrip.json",
+		},
+		{
+			name:     "YAML round trip",
+			filename: "roundtrip.yaml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(tmpDir, tc.filename)
+
+			// Store and save original config
+			Config.Store(originalConfig)
+			if err := SaveServerConfig(configPath); err != nil {
+				t.Fatalf("Failed to save config: %v", err)
+			}
+
+			// Load the config back
+			if err := LoadServerConfig(configPath); err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+
+			// Verify all fields match
+			loaded := Config.Load()
+			if loaded.UserMaxConnections != originalConfig.UserMaxConnections {
+				t.Errorf("UserMaxConnections: got %d, expected %d", loaded.UserMaxConnections, originalConfig.UserMaxConnections)
+			}
+			if loaded.PingTimeoutMinutes != originalConfig.PingTimeoutMinutes {
+				t.Errorf("PingTimeoutMinutes: got %d, expected %d", loaded.PingTimeoutMinutes, originalConfig.PingTimeoutMinutes)
+			}
+			if loaded.DHCPTimeoutHours != originalConfig.DHCPTimeoutHours {
+				t.Errorf("DHCPTimeoutHours: got %d, expected %d", loaded.DHCPTimeoutHours, originalConfig.DHCPTimeoutHours)
+			}
+			if loaded.VPNIP != originalConfig.VPNIP {
+				t.Errorf("VPNIP: got %s, expected %s", loaded.VPNIP, originalConfig.VPNIP)
+			}
+			if loaded.VPNPort != originalConfig.VPNPort {
+				t.Errorf("VPNPort: got %s, expected %s", loaded.VPNPort, originalConfig.VPNPort)
+			}
+			if loaded.Hostname != originalConfig.Hostname {
+				t.Errorf("Hostname: got %s, expected %s", loaded.Hostname, originalConfig.Hostname)
+			}
+			if len(loaded.Features) != len(originalConfig.Features) {
+				t.Errorf("Features length: got %d, expected %d", len(loaded.Features), len(originalConfig.Features))
+			}
+
+			t.Logf("Round trip test passed for %s ✓", tc.filename)
 		})
 	}
 }

--- a/server/new_api.go
+++ b/server/new_api.go
@@ -28,6 +28,7 @@ func launchAPIServer() {
 		mux.HandleFunc("/v3/devices", API_ListDevices) // supports ADMIN APIKey
 	}
 
+	mux.HandleFunc("/v3/session", API_SessionCreate)
 	if VPNEnabled {
 		mux.HandleFunc("/v3/connect", API_AcceptUserConnections)
 	}
@@ -61,7 +62,6 @@ func launchAPIServer() {
 		mux.HandleFunc("/v3/server/create", API_ServerCreate)
 		mux.HandleFunc("/v3/server/update", API_ServerUpdate)
 		mux.HandleFunc("/v3/servers", API_ServersForUser)
-		mux.HandleFunc("/v3/session", API_SessionCreate)
 
 		// Tunnels public network specific
 		if loadSecret("PayKey") != "" {

--- a/server/new_api.go
+++ b/server/new_api.go
@@ -25,11 +25,11 @@ func launchAPIServer() {
 
 	if LANEnabled {
 		mux.HandleFunc("/v3/firewall", API_Firewall)
-		mux.HandleFunc("/v3/devices", API_ListDevices) // supports ADMIN APIKey
+		mux.HandleFunc("/v3/devices", API_ListDevices)
 	}
 
 	mux.HandleFunc("/v3/session", API_SessionCreate)
-	if VPNEnabled {
+	if VPNEnabled || LANEnabled {
 		mux.HandleFunc("/v3/connect", API_AcceptUserConnections)
 	}
 
@@ -43,8 +43,8 @@ func launchAPIServer() {
 		mux.HandleFunc("/v3/user/2fa/confirm", API_UserTwoFactorConfirm)
 		mux.HandleFunc("/v3/user/list", API_UserList)
 
-		mux.HandleFunc("/v3/device/list", API_DeviceList)     // supports ADMIN APIKey
-		mux.HandleFunc("/v3/device/create", API_DeviceCreate) // supports ADMIN APIKey
+		mux.HandleFunc("/v3/device/list", API_DeviceList)
+		mux.HandleFunc("/v3/device/create", API_DeviceCreate)
 		mux.HandleFunc("/v3/device/delete", API_DeviceDelete)
 		mux.HandleFunc("/v3/device/update", API_DeviceUpdate)
 		mux.HandleFunc("/v3/device", API_DeviceGet)

--- a/server/new_api.go
+++ b/server/new_api.go
@@ -114,19 +114,23 @@ func loggingTimingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
 		conf := Config.Load()
-		if conf.LogAPIHosts {
+		if conf.LogAPIHosts && !disableLogs {
 			log.Printf("-> %s %s %s", r.RemoteAddr, r.Method, r.URL.RequestURI())
 		} else {
-			log.Printf("-> %s %s", r.Method, r.URL.RequestURI())
+			if !disableLogs {
+				log.Printf("-> %s %s", r.Method, r.URL.RequestURI())
+			}
 		}
 
 		next.ServeHTTP(w, r)
-		duration := time.Since(startTime)
-		log.Printf("<- %s %s completed in %d ms",
-			r.Method,
-			r.URL.RequestURI(),
-			duration.Milliseconds(),
-		)
+		if !disableLogs {
+			duration := time.Since(startTime)
+			log.Printf("<- %s %s completed in %d ms",
+				r.Method,
+				r.URL.RequestURI(),
+				duration.Milliseconds(),
+			)
+		}
 	})
 }
 

--- a/server/new_api.go
+++ b/server/new_api.go
@@ -68,7 +68,6 @@ func launchAPIServer() {
 			mux.HandleFunc("/v3/key/activate", API_ActivateLicenseKey)
 			mux.HandleFunc("/v3/user/toggle/substatus", API_UserToggleSubStatus)
 		}
-
 	}
 
 	tlsConfig := APITLSConfig.Load()

--- a/server/ping.go
+++ b/server/ping.go
@@ -28,7 +28,6 @@ func PopulatePingBufferWithStats() {
 	if err != nil {
 		ERR("Unable to get mem stats", err)
 		return
-
 	}
 	PingPongStatsBuffer[1] = byte(int(memStats.UsedPercent))
 
@@ -61,11 +60,11 @@ func NukeClient(index int) {
 		}
 	}
 
-	// Not removing yet, but there is no need to un-assign from the lan due to DHCP presistence.
-	if clientCoreMappings[index].DHCP != nil {
-		// ip := clientCoreMappings[index].DHCP.IP
-		// VPLIPToCore[ip[0]][ip[1]][ip[2]][ip[3]] = nil
-	}
+	// Not removing yet, but there is no need to un-assign from the lan due to DHCP lease timer.
+	// if clientCoreMappings[index].DHCP != nil {
+	// ip := clientCoreMappings[index].DHCP.IP
+	// VPLIPToCore[ip[0]][ip[1]][ip[2]][ip[3]] = nil
+	// }
 
 	close(clientCoreMappings[index].ToUser)
 	close(clientCoreMappings[index].FromUser)

--- a/server/ratelimiter.go
+++ b/server/ratelimiter.go
@@ -43,7 +43,7 @@ func Ratelimit(conn net.Conn) (allowed bool) {
 	} else {
 		limiter.Count++
 		if limiter.Count > 100 {
-			WARN(3, "RATELIMIT HIT FOR IP: ", IP)
+			WARN( "RATELIMIT HIT FOR IP: ", IP)
 			return false
 		}
 	}

--- a/server/ratelimiter.go
+++ b/server/ratelimiter.go
@@ -43,7 +43,7 @@ func Ratelimit(conn net.Conn) (allowed bool) {
 	} else {
 		limiter.Count++
 		if limiter.Count > 100 {
-			WARN( "RATELIMIT HIT FOR IP: ", IP)
+			WARN("RATELIMIT HIT FOR IP: ", IP)
 			return false
 		}
 	}

--- a/server/socket.go
+++ b/server/socket.go
@@ -214,12 +214,13 @@ func ExternalUDPListener() {
 	}
 
 	var DSTP uint16
-	var IHL byte
+	var IPHeadLength byte
 	var PM *PortRange
 	var n int
 	var version byte
 	buffer := make([]byte, math.MaxUint16)
-	// cfg := Config.Load()
+	cfg := Config.Load()
+	startPort := uint16(cfg.StartPort)
 
 	for {
 		n, _, err = syscall.Recvfrom(rawUDPSockFD, buffer, 0)
@@ -234,11 +235,11 @@ func ExternalUDPListener() {
 		}
 
 		// TODO .. use mask
-		IHL = ((buffer[0] << 4) >> 4) * 4
-		DSTP = binary.BigEndian.Uint16(buffer[IHL+2 : IHL+4])
-		// if DSTP < uint16(cfg.StartPort) {
-		// 	continue
-		// }
+		IPHeadLength = ((buffer[0] << 4) >> 4) * 4
+		DSTP = binary.BigEndian.Uint16(buffer[IPHeadLength+2 : IPHeadLength+4])
+		if DSTP < startPort {
+			continue
+		}
 		PM = portToCoreMapping[DSTP]
 		if PM == nil || PM.Client == nil {
 			continue

--- a/server/socket.go
+++ b/server/socket.go
@@ -319,7 +319,7 @@ func fromUserChannel(index int) {
 	shouldRestart := true
 	defer func() {
 		if r := recover(); r != nil {
-			ERR(3, r, string(debug.Stack()))
+			ERR( r, string(debug.Stack()))
 		}
 
 		if !shouldRestart {
@@ -483,7 +483,7 @@ func toUserChannel(index int) {
 
 	defer func() {
 		if r := recover(); r != nil {
-			ERR(3, r, string(debug.Stack()))
+			ERR( r, string(debug.Stack()))
 		}
 
 		if !shouldRestart {

--- a/server/socket_test.go
+++ b/server/socket_test.go
@@ -34,8 +34,8 @@ func TestHashIdentifierSHA3_Consistency(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Hash the same value twice
-			hash1 := HashIdentifier(tc.input)
-			hash2 := HashIdentifier(tc.input)
+			hash1 := hashIdentifier(tc.input)
+			hash2 := hashIdentifier(tc.input)
 
 			// Verify they are identical as strings
 			if hash1 != hash2 {
@@ -63,8 +63,8 @@ func TestHashIdentifierSHA3_Uniqueness(t *testing.T) {
 	input1 := "device-token-1"
 	input2 := "device-token-2"
 
-	hash1 := HashIdentifier(input1)
-	hash2 := HashIdentifier(input2)
+	hash1 := hashIdentifier(input1)
+	hash2 := hashIdentifier(input2)
 
 	if hash1 == hash2 {
 		t.Errorf("Different inputs produced the same hash!\nInput1: %s\nInput2: %s\nHash: %s",
@@ -80,7 +80,7 @@ func TestHashIdentifierSHA3_KnownValue(t *testing.T) {
 	input := "test-device-token-123"
 	expectedHash := "4d3d1ccc7011a8d1fa523c9e2bd91c188fbe657f77c8bc3f36981e11ca011e04"
 
-	hash := HashIdentifier(input)
+	hash := hashIdentifier(input)
 
 	if hash != expectedHash {
 		t.Errorf("Hash does not match expected value!\nExpected: %s\nGot:      %s", expectedHash, hash)


### PR DESCRIPTION
## Summary

This PR includes several improvements across configuration handling, logging, security, and code quality.

### Configuration
- **YAML Support**: Added support for YAML configuration files (`.yaml`, `.yml`) in addition to JSON (`.json`, `.conf`) for both client configs and tunnel definitions
- File format is auto-detected based on extension
- Full read/write round-trip support for both formats

### Testing
- Added comprehensive test suite for configuration handling (`client/config_test.go`)
  - JSON and YAML read/write tests
  - Round-trip serialization tests
  - Error handling for invalid formats and content
  - Tunnel save/load cycle tests

### Logging
- Extracted logging functions to dedicated `server/logging.go`
- Added CLI flags:
  - `-logLevel` (debug, info, warn, error)
  - `-json` (toggle JSON logging format)
  - `-source` (toggle source line info)
- Simplified log function signatures (removed log level parameter)

### Security
- Removed deprecated cryptographic options from server API:
  - AES128
  - CurveP521
  - TLS 1.2

### Code Quality
- Added `server/.golangci.yml` with comprehensive linting rules
- Refactored socket creation functions with explicit return values
- Replaced `interface{}` with `any`
- Cleaned up nil checks (`S.Groups == nil || len(S.Groups) == 0` → `len(S.Groups) == 0`)
- Various error handling improvements

### Other
- Enabled `/connect` endpoint when only LAN feature is selected
- Updated Go version to 1.25.0
- Added `gopkg.in/yaml.v3` as direct dependency

## Files Changed
- `client/config.go` - YAML support
- `client/config_test.go` - New test suite (+557 lines)
- `server/logging.go` - New centralized logging (+82 lines)
- `server/main.go` - CLI flags and logging integration
- `server/main_test.go` - Expanded tests (+558 lines)
- `server/.golangci.yml` - New linter config
- Various files with logging and code cleanup